### PR TITLE
Updates client-nodejs to use latest SessionService gRPC API

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -62,7 +62,8 @@ npm_package(
         ":bundle",
         "@nodejs_dependencies//grpc",
         "@nodejs_dependencies//google-protobuf"
-    ]
+    ],
+    visibility = ["//visibility:public"]
 )
 
 deploy_npm(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "graknlabs_grakn_core",
     remote = "https://github.com/graknlabs/grakn",
-    commit = "f0959ee2681b5c2fe850aa7b697c35b2c2d4d720"
+    commit = "99f1068680e22662c960cd7a9d2e98ab9baf3d17"
 )
 
 git_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "graknlabs_grakn_core",
     remote = "https://github.com/graknlabs/grakn",
-    commit = "99f1068680e22662c960cd7a9d2e98ab9baf3d17"
+    commit = "80a9d8f01cb2fe642b9c29d0c550987dee3feb67"
 )
 
 git_repository(

--- a/src/service/Session/SessionService.js
+++ b/src/service/Session/SessionService.js
@@ -33,9 +33,9 @@ function SessionService(uri, keyspace, credentials) {
     this.stub = new services.SessionServiceClient(uri, grpc.credentials.createInsecure());
 }
 
-function wrapInPromise(fn, requestMessage){
+function wrapInPromise(self, fn, requestMessage){
     return new Promise((resolve, reject) => {
-        fn.call(requestMessage, (error, response) => {
+        fn.call(self, requestMessage, (error, response) => {
             if (error) { reject(error); }
             resolve(response);
         });
@@ -50,7 +50,7 @@ function wrapInPromise(fn, requestMessage){
  */
 SessionService.prototype.transaction = async function create(txType) {
     if (this.sessionId === undefined) {
-        this.sessionId = (await wrapInPromise(this.stub.open, RequestBuilder.openSession(this.keyspace))).getSessionid();
+        this.sessionId = (await wrapInPromise(this.stub, this.stub.open, RequestBuilder.openSession(this.keyspace))).getSessionid();
     }
 
     const txService = new TxService(this.stub.transaction());
@@ -62,7 +62,7 @@ SessionService.prototype.transaction = async function create(txType) {
  * Closes connection to the server
  */
 SessionService.prototype.close = async function close() {
-    await wrapInPromise(this.stub.close, RequestBuilder.closeSession(this.sessionId));
+    await wrapInPromise(this.stub, this.stub.close, RequestBuilder.closeSession(this.sessionId));
     grpc.closeClient(this.stub);
 }
 

--- a/src/service/Session/TransactionService.js
+++ b/src/service/Session/TransactionService.js
@@ -346,8 +346,8 @@ TransactionService.prototype.getAttributesByValue = function (value, dataType) {
         .then(response => this.respConverter.getAttributesByValue(response));
 }
 
-TransactionService.prototype.openTx = function (keyspace, txType, credentials) {
-    const txRequest = RequestBuilder.openTx(keyspace, txType, credentials);
+TransactionService.prototype.openTx = function (session_id, txType, credentials) {
+    const txRequest = RequestBuilder.openTx(session_id, txType, credentials);
     return this.communicator.send(txRequest);
 };
 

--- a/src/service/Session/TransactionService.js
+++ b/src/service/Session/TransactionService.js
@@ -346,8 +346,8 @@ TransactionService.prototype.getAttributesByValue = function (value, dataType) {
         .then(response => this.respConverter.getAttributesByValue(response));
 }
 
-TransactionService.prototype.openTx = function (session_id, txType, credentials) {
-    const txRequest = RequestBuilder.openTx(session_id, txType, credentials);
+TransactionService.prototype.openTx = function (sessionId, txType, credentials) {
+    const txRequest = RequestBuilder.openTx(sessionId, txType, credentials);
     return this.communicator.send(txRequest);
 };
 

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -490,6 +490,16 @@ const methods = {
     txRequest.setGetattributesReq(getAttributesReq);
     return txRequest;
   },
+  openSession: function(keyspace) {
+    const sessionRequest = new messages.Session.Open.Req();
+    sessionRequest.setKeyspace(keyspace);
+    return sessionRequest;
+  },
+  closeSession: function(sessionId) {
+    const sessionRequest = new messages.Session.Close.Req();
+    sessionRequest.setSessionid(sessionId);
+    return sessionRequest;
+  },
   openTx: function (session_id, txType, credentials) {
     const openRequest = new messages.Transaction.Open.Req();
     const txRequest = new messages.Transaction.Req();

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -490,10 +490,10 @@ const methods = {
     txRequest.setGetattributesReq(getAttributesReq);
     return txRequest;
   },
-  openTx: function (keyspace, txType, credentials) {
+  openTx: function (session_id, txType, credentials) {
     const openRequest = new messages.Transaction.Open.Req();
     const txRequest = new messages.Transaction.Req();
-    openRequest.setKeyspace(keyspace);
+    openRequest.setSessionid(session_id);
     openRequest.setType(txType);
     if (credentials) {
       openRequest.setUsername(credentials.username);

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -500,10 +500,10 @@ const methods = {
     sessionRequest.setSessionid(sessionId);
     return sessionRequest;
   },
-  openTx: function (session_id, txType, credentials) {
+  openTx: function (sessionId, txType, credentials) {
     const openRequest = new messages.Transaction.Open.Req();
     const txRequest = new messages.Transaction.Req();
-    openRequest.setSessionid(session_id);
+    openRequest.setSessionid(sessionId);
     openRequest.setType(txType);
     if (credentials) {
       openRequest.setUsername(credentials.username);


### PR DESCRIPTION
# Why is this PR needed?

Fixes #5 
So we are able to use `client-nodejs` with the latest `@graknlabs_grakn_core`

# What does the PR do?

- Upgrades commit hash of `@graknlabs_grakn_core`
- Fixes the client to comply with new API

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—