### PR TITLE
Automatically deploy master branch to test NPM registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,20 @@ jobs:
       - run: nohup bazel-genfiles/dist/grakn-core-all/grakn server start
       - run: bazel-genfiles/dist/grakn-core-all/grakn console -f `pwd`/tests/support/basic-genealogy.gql -k gene
       - run: bazel test //:test-integration --test_output=streamed
+  test-repo-deploy:
+    machine: true
+    working_directory: ~/grakn
+    steps:
+      - checkout
+      - bazel_install
+      - run: bazel run //:deploy-npm -- test $TEST_REPO_USERNAME $TEST_REPO_PASSWORD $TEST_REPO_EMAIL
 
 workflows:
   version: 2
   grakn-client-nodejs-ci:
     jobs:
       - client-nodejs
+      - test-repo-deploy:
+          filters:
+            branches:
+              only: master

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "graknlabs_grakn_core",
     remote = "https://github.com/graknlabs/grakn",
-    commit = "80a9d8f01cb2fe642b9c29d0c550987dee3feb67"
+    commit = "ec41e803e3a12696cec731ad6071c26e90cea926"
 )
 
 git_repository(
@@ -41,7 +41,7 @@ node_grpc_compile()
 git_repository(
     name="graknlabs_bazel_distribution",
     remote="https://github.com/graknlabs/bazel-distribution",
-    commit="bef0d2638a19b710a54d5786855aa9ef60fea238"
+    commit="18d774e16187bd4148fe36842b68bafa46017d6f"
 )
 
 


### PR DESCRIPTION
## What is the goal of this PR?

Fixes #9

`master` branch of `client-nodejs` will be automatically deployed to test NPM registry at [repo.grakn.ai](http://repo.grakn.ai); configured [here](https://github.com/graknlabs/grakn/blob/ec41e803e3a12696cec731ad6071c26e90cea926/deployment.properties#L27)

## What are the changes implemented in this PR?

- Added invocation of `//:deploy-npm` `bazel` target on `master` branch
