### PR TITLE
Install 'expect' package on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
     steps:
       - checkout
       - bazel_install
+      - run: sudo apt install -y expect
       - run: bazel run //:deploy-npm -- test $TEST_REPO_USERNAME $TEST_REPO_PASSWORD $TEST_REPO_EMAIL
 
 workflows:


### PR DESCRIPTION
## What is the goal of this PR?

Fixing `//:deploy-npm` (it requires `expect` binary to be present at `PATH`)

## What are the changes implemented in this PR?

Installing `expect` through `apt`
