### PR TITLE
Fix package name and version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,7 +41,7 @@ node_grpc_compile()
 git_repository(
     name="graknlabs_bazel_distribution",
     remote="https://github.com/graknlabs/bazel-distribution",
-    commit="4fe70b386f57727b8d97d3a5b712ab4defef5f90"
+    commit="ba435c28b289064896e6e278d23340dc9c390ad6"
 )
 
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "grakn",
+  "name": "grakn-client",
   "version": "0.0.0-development",
   "description": "Grakn Node.js Client",
   "main": "src/Grakn.js",


### PR DESCRIPTION
## What is the goal of this PR?

Complying with CI/CD plan outlined [here](http://tinyurl.com/GraknCICDSpreadsheet), we're renaming `grakn` to `grakn-client` and are using updated `@graknlabs_bazel_distribution` which stamp the `git` version to snapshot packages

## What are the changes implemented in this PR?

- rename `grakn` to `grakn-client`
- update commit hash of `@graknlabs_bazel_distribution`