### PR TITLE
Bump @build_bazel_rules_nodejs version to latest 'experimental'

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,7 +9,7 @@ git_repository(
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/graknlabs/rules_nodejs.git",
-    commit = "ac3f6854365f119130186f971588514ccff503ab",
+    commit = "1c9b8cb1e1f39214fe27bafa44d1597cdc9d8ff5",
 )
 
 load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")


### PR DESCRIPTION
## What is the goal of this PR?

Fixes first part of graknlabs/grakn#4803

## What are the changes implemented in this PR?

Upgrades `@build_bazel_rules_nodejs` to a version that includes a fix to 

````
DEBUG: /private/var/tmp/_bazel_<>/<>/external/bazel_skylib/lib.bzl:30:1: WARNING: lib.bzl is deprecated and will go away in the future, please directly load the bzl file(s) of the module(s) needed as it is more efficient.
````