### PR TITLE
Add grabl-marker for autoupdating

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "graknlabs_grakn_core",
     remote = "https://github.com/graknlabs/grakn",
-    commit = "2091602fbcca45823d2bc3d5062ce7cdb6b25b89"
+    commit = "2091602fbcca45823d2bc3d5062ce7cdb6b25b89" # grabl-marker: do not remove this comment, this is used for dependency-update by @graknlabs_grakn_core
 )
 
 git_repository(


### PR DESCRIPTION
## What is the goal of this PR?

Needed for https://github.com/graknlabs/grabl/issues/14

## What are the changes implemented in this PR?

Adds `grabl-marker` so dependency script knows how to update it