### PR TITLE
Add benchmark as transitive dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,9 +97,11 @@ node_grpc_compile()
 # Load Grakn Core dependencies #
 ################################
 
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_graql", "graknlabs_client_java")
+load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
+     "graknlabs_graql", "graknlabs_client_java", "graknlabs_benchmark")
 graknlabs_graql()
 graknlabs_client_java()
+graknlabs_benchmark()
 
 load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl",
 graknlabs_grakn_core_maven_dependencies = "maven_dependencies")


### PR DESCRIPTION
## What is the goal of this PR?
Fix breaking change caused by the introduction of `benchmark` repository as a Bazel git_repository dependency.

## What are the changes implemented in this PR?
One liner to include `graknlabs_benchmark()` dependency that allows the building of distribution `tar.gz` in CircleCI.