### PR TITLE
Update internal protocol to be compatible with Grakn Core and KGMS 1.5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ workflows:
       - deploy-npm-snapshot:
           filters:
             branches:
-              only: "kgms-1.5.2" # TODO: revert to master
+              only: master
           requires:
             - build
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ workflows:
       - deploy-npm-snapshot:
           filters:
             branches:
-              only: master
+              only: "kgms-1.5.2" # TODO: revert to master
           requires:
             - build
             - test

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,5 +29,5 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        tag = "1.5.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "0647df0d32623402208fa150ba75c291d9c18e56" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )

--- a/src/GraknClient.js
+++ b/src/GraknClient.js
@@ -42,8 +42,8 @@ function GraknClient(uri, credentials) {
     const keyspaceService = new KeyspaceService(keyspaceClient, credentials);
 
     this.session = async (keyspace) => { 
-        const session = new Session(sessionClient, credentials);
-        await session.open(keyspace);
+        const session = new Session(sessionClient);
+        await session.open(keyspace, credentials);
         return session;
     };
 

--- a/src/Session.js
+++ b/src/Session.js
@@ -36,16 +36,16 @@ const txType = {
  * @param {Object} grpcClient grpc node client (session stub + channel)
  * @param {Object} credentials Optional object containing user credentials - only used when connecting to a KGMS instance
  */
-function Session(grpcClient, credentials) {
-  this.sessionService = new SessionService(grpcClient, credentials);
+function Session(grpcClient) {
+  this.sessionService = new SessionService(grpcClient);
 }
 
 /**
  * Open a new Session on the server side
  * @param {String} keyspace Grakn keyspace to which this sessions should be bound to
  */
-Session.prototype.open = function(keyspace){
-  return this.sessionService.open(keyspace);
+Session.prototype.open = function(keyspace, credentials){
+  return this.sessionService.open(keyspace, credentials);
 }
 
 /**

--- a/src/service/Session/SessionService.js
+++ b/src/service/Session/SessionService.js
@@ -24,8 +24,7 @@ const RequestBuilder = require("./util/RequestBuilder");
  * This creates a new connection to the server over HTTP2,
  * the connection will contain all the Transaction streams
  */
-function SessionService(grpcClient, credentials) {
-    this.credentials = credentials;
+function SessionService(grpcClient) {
     this.client = grpcClient;
 }
 
@@ -33,7 +32,7 @@ function SessionService(grpcClient, credentials) {
  * This sends an open Session request and retrieves the sessionId that will be needed
  * to open a Transaction.
  */
-SessionService.prototype.open = async function open(keyspace){
+SessionService.prototype.open = async function open(keyspace, credentials){
     const openResponse = await wrapInPromise(this.client, this.client.open, RequestBuilder.openSession(keyspace));
     this.sessionId = openResponse.getSessionid();
 }
@@ -46,7 +45,7 @@ SessionService.prototype.open = async function open(keyspace){
  */
 SessionService.prototype.transaction = async function create(txType) {
     const txService = new TxService(this.client.transaction());
-    await txService.openTx(this.sessionId, txType, this.credentials);
+    await txService.openTx(this.sessionId, txType);
     return txService;
 }
 

--- a/src/service/Session/SessionService.js
+++ b/src/service/Session/SessionService.js
@@ -33,7 +33,7 @@ function SessionService(grpcClient) {
  * to open a Transaction.
  */
 SessionService.prototype.open = async function open(keyspace, credentials){
-    const openResponse = await wrapInPromise(this.client, this.client.open, RequestBuilder.openSession(keyspace));
+    const openResponse = await wrapInPromise(this.client, this.client.open, RequestBuilder.openSession(keyspace, credentials));
     this.sessionId = openResponse.getSessionid();
 }
 

--- a/src/service/Session/TransactionService.js
+++ b/src/service/Session/TransactionService.js
@@ -346,8 +346,8 @@ TransactionService.prototype.getAttributesByValue = function (value, dataType) {
         .then(response => this.respConverter.getAttributesByValue(response));
 }
 
-TransactionService.prototype.openTx = function (sessionId, txType, credentials) {
-    const txRequest = RequestBuilder.openTx(sessionId, txType, credentials);
+TransactionService.prototype.openTx = function (sessionId, txType) {
+    const txRequest = RequestBuilder.openTx(sessionId, txType);
     return this.communicator.send(txRequest);
 };
 

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -490,8 +490,12 @@ const methods = {
     txRequest.setGetattributesReq(getAttributesReq);
     return txRequest;
   },
-  openSession: function(keyspace) {
+  openSession: function(keyspace, credentials) {
     const sessionRequest = new messages.Session.Open.Req();
+    if (credentials) {
+      sessionRequest.setUsername(credentials.username);
+      sessionRequest.setPassword(credentials.password);
+    }
     sessionRequest.setKeyspace(keyspace);
     return sessionRequest;
   },
@@ -500,15 +504,11 @@ const methods = {
     sessionRequest.setSessionid(sessionId);
     return sessionRequest;
   },
-  openTx: function (sessionId, txType, credentials) {
+  openTx: function (sessionId, txType) {
     const openRequest = new messages.Transaction.Open.Req();
     const txRequest = new messages.Transaction.Req();
     openRequest.setSessionid(sessionId);
     openRequest.setType(txType);
-    if (credentials) {
-      openRequest.setUsername(credentials.username);
-      openRequest.setPassword(credentials.password);
-    }
     txRequest.setOpenReq(openRequest);
     return txRequest;
   },


### PR DESCRIPTION
## What is the goal of this PR?

Grakn Core 1.5.2 introduced a protocol change which rendered `client-nodejs` version 1.5.1 and older incompatible. We have updated `client-nodejs` to allow it to connect to Grakn Core and KGMS 1.5.2.

The changes that had been introduced are internal changes which did not affect the public API.

## What are the changes implemented in this PR?

- Internally, `username` and `password` are now supplied when making the `Session.Open.Req` gRPC request as opposed to 1.5.1 where they were supplied when making the `Transaction.Open.Req` request