### PR TITLE
Add .get(v) to ConceptMap

### DIFF
--- a/src/service/Session/util/AnswerFactory.js
+++ b/src/service/Session/util/AnswerFactory.js
@@ -49,6 +49,7 @@ AnswerFactory.prototype.createConceptmap = function (answer) {
         });
     return {
         map: () => answerMap,
+        get: (v) => answerMap.get(v),
         explanation: () => this.buildExplanation(answer.getExplanation())
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Fix #40

## What are the changes implemented in this PR?

Adds `.get(var)` (`var` is a reserved keyword in NodeJS) method to `ConceptMap`