### PR TITLE
Update Grakn Client NodeJS to use latest @graknlabs_protocol

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -23,21 +23,10 @@ exports_files([
     "RELEASE_TEMPLATE.md",
 ])
 
-load("@stackb_rules_proto//node:node_grpc_compile.bzl", "node_grpc_compile")
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package", "nodejs_jest_test", "babel_library")
-load("@graknlabs_bazel_distribution//npm:rules.bzl", "deploy_npm")
+load("@graknlabs_bazel_distribution//npm:rules.bzl", "assemble_npm", "new_deploy_npm")
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 
-
-node_grpc_compile(
-    name = "client-nodejs-proto",
-    deps = [
-        "@graknlabs_grakn_core//protocol/session:session-proto",
-        "@graknlabs_grakn_core//protocol/session:answer-proto",
-        "@graknlabs_grakn_core//protocol/session:concept-proto",
-        "@graknlabs_grakn_core//protocol/keyspace:keyspace-proto",
-    ]
-)
 
 babel_library(
     name = 'bundle',
@@ -61,18 +50,26 @@ babel_library(
 npm_package(
     name = "client-nodejs",
     deps = [
-        ":client-nodejs-proto",
+        "@graknlabs_protocol//:client-nodejs-proto",
         ":bundle",
         "@nodejs_dependencies//grpc",
         "@nodejs_dependencies//google-protobuf"
     ],
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+    vendor_external = [
+        "graknlabs_protocol"
+    ]
 )
 
-deploy_npm(
-    name = "deploy-npm",
+assemble_npm(
+    name = "assemble-npm",
     target = ":client-nodejs",
     version_file = "//:VERSION",
+)
+
+new_deploy_npm(
+    name = "deploy-npm",
+    target = ":assemble-npm",
     deployment_properties = "@graknlabs_build_tools//:deployment.properties",
 )
 

--- a/BUILD
+++ b/BUILD
@@ -50,7 +50,7 @@ babel_library(
 npm_package(
     name = "client-nodejs",
     deps = [
-        "@graknlabs_protocol//:client-nodejs-proto",
+        "@graknlabs_protocol//grpc/nodejs:protocol",
         ":bundle",
         "@nodejs_dependencies//grpc",
         "@nodejs_dependencies//google-protobuf"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,9 +23,10 @@ workspace(name = "graknlabs_client_nodejs")
 # Grakn Labs dependencies #
 ###########################
 
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_grakn_core", "graknlabs_build_tools")
+load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_grakn_core", "graknlabs_build_tools", "graknlabs_protocol")
 graknlabs_grakn_core()
 graknlabs_build_tools()
+graknlabs_protocol()
 
 load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "2832af3c237551cd132907dfd1790ed503208e78", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "1af886c69172839d9f2b527046be3201370d5397", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():
@@ -30,4 +30,11 @@ def graknlabs_grakn_core():
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
         commit = "8fbb82691c9d0abfd651f075bb06eb689b8536de" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+    )
+
+def graknlabs_protocol():
+    git_repository(
+        name = "graknlabs_protocol",
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "857fef48e2077bcaeb454e31e271910cf5056114" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,19 +22,19 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "1af886c69172839d9f2b527046be3201370d5397", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "8823be45d1d6898983513e0a64514184003602ab", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "8fbb82691c9d0abfd651f075bb06eb689b8536de" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "403bd6a170b2419594999061ab5c3ee580af0ada" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "857fef48e2077bcaeb454e31e271910cf5056114" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "92d1b01a07197ded8290a2afe624d5308f749d5c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )

--- a/src/GraknClient.js
+++ b/src/GraknClient.js
@@ -20,9 +20,9 @@
 const grpc = require("grpc");
 const Session = require('./Session');
 const KeyspaceService = require('./service/Keyspace/KeyspaceService');
-const messages = require("../client-nodejs-proto/session/Session_pb");
-const sessionServices = require("../client-nodejs-proto/session/Session_grpc_pb");
-const keyspaceServices = require("../client-nodejs-proto/keyspace/Keyspace_grpc_pb");
+const messages = require("../grpc/nodejs/protocol/session/Session_pb");
+const sessionServices = require("../grpc/nodejs/protocol/session/Session_grpc_pb");
+const keyspaceServices = require("../grpc/nodejs/protocol/keyspace/Keyspace_grpc_pb");
 
 /**
  * Entry-point for Grakn client, it communicates with a running Grakn server using gRPC.

--- a/src/GraknClient.js
+++ b/src/GraknClient.js
@@ -20,9 +20,9 @@
 const grpc = require("grpc");
 const Session = require('./Session');
 const KeyspaceService = require('./service/Keyspace/KeyspaceService');
-const messages = require("../client-nodejs-proto/protocol/session/Session_pb");
-const sessionServices = require("../client-nodejs-proto/protocol/session/Session_grpc_pb");
-const keyspaceServices = require("../client-nodejs-proto/protocol/keyspace/Keyspace_grpc_pb");
+const messages = require("../client-nodejs-proto/session/Session_pb");
+const sessionServices = require("../client-nodejs-proto/session/Session_grpc_pb");
+const keyspaceServices = require("../client-nodejs-proto/keyspace/Keyspace_grpc_pb");
 
 /**
  * Entry-point for Grakn client, it communicates with a running Grakn server using gRPC.

--- a/src/Session.js
+++ b/src/Session.js
@@ -19,7 +19,7 @@
 
 const Transaction = require("./Transaction");
 const SessionService = require("./service/Session/SessionService");
-const messages = require("../client-nodejs-proto/session/Session_pb");
+const messages = require("../grpc/nodejs/protocol/session/Session_pb");
 
 /**
  * List of available transaction types supported by Grakn

--- a/src/Session.js
+++ b/src/Session.js
@@ -19,7 +19,7 @@
 
 const Transaction = require("./Transaction");
 const SessionService = require("./service/Session/SessionService");
-const messages = require("../client-nodejs-proto/protocol/session/Session_pb");
+const messages = require("../client-nodejs-proto/session/Session_pb");
 
 /**
  * List of available transaction types supported by Grakn

--- a/src/service/Keyspace/KeyspaceService.js
+++ b/src/service/Keyspace/KeyspaceService.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const messages = require("../../../client-nodejs-proto/protocol/keyspace/Keyspace_pb");
+const messages = require("../../../client-nodejs-proto/keyspace/Keyspace_pb");
 
 function KeyspaceService(grpcClient, credentials) {
     this.credentials = credentials;

--- a/src/service/Keyspace/KeyspaceService.js
+++ b/src/service/Keyspace/KeyspaceService.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const messages = require("../../../client-nodejs-proto/keyspace/Keyspace_pb");
+const messages = require("../../../grpc/nodejs/protocol/keyspace/Keyspace_pb");
 
 function KeyspaceService(grpcClient, credentials) {
     this.credentials = credentials;

--- a/src/service/Session/concept/ConceptFactory.js
+++ b/src/service/Session/concept/ConceptFactory.js
@@ -18,7 +18,7 @@
  */
 
 const Methods = require("./Methods");
-const ConceptGrpcMessages = require("../../../../client-nodejs-proto/protocol/session/Concept_pb");
+const ConceptGrpcMessages = require("../../../../client-nodejs-proto/session/Concept_pb");
 const BaseType = require("./BaseTypeConstants").baseType;
 
 /**

--- a/src/service/Session/concept/ConceptFactory.js
+++ b/src/service/Session/concept/ConceptFactory.js
@@ -18,7 +18,7 @@
  */
 
 const Methods = require("./Methods");
-const ConceptGrpcMessages = require("../../../../client-nodejs-proto/session/Concept_pb");
+const ConceptGrpcMessages = require("../../../../grpc/nodejs/protocol/session/Concept_pb");
 const BaseType = require("./BaseTypeConstants").baseType;
 
 /**

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-const messages = require("../../../../client-nodejs-proto/protocol/session/Session_pb");
+const messages = require("../../../../client-nodejs-proto/session/Session_pb");
 const ConceptsBaseType = require("../concept/BaseTypeConstants").baseType;
-const ProtoDataType = require("../../../../client-nodejs-proto/protocol/session/Concept_pb").AttributeType.DATA_TYPE;
+const ProtoDataType = require("../../../../client-nodejs-proto/session/Concept_pb").AttributeType.DATA_TYPE;
 const INFER_TRUE_MESSAGE = messages.Transaction.Query.INFER.TRUE;
 const INFER_FALSE_MESSAGE = messages.Transaction.Query.INFER.FALSE;
 

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-const messages = require("../../../../client-nodejs-proto/session/Session_pb");
+const messages = require("../../../../grpc/nodejs/protocol/session/Session_pb");
 const ConceptsBaseType = require("../concept/BaseTypeConstants").baseType;
-const ProtoDataType = require("../../../../client-nodejs-proto/session/Concept_pb").AttributeType.DATA_TYPE;
+const ProtoDataType = require("../../../../grpc/nodejs/protocol/session/Concept_pb").AttributeType.DATA_TYPE;
 const INFER_TRUE_MESSAGE = messages.Transaction.Query.INFER.TRUE;
 const INFER_FALSE_MESSAGE = messages.Transaction.Query.INFER.FALSE;
 

--- a/src/service/Session/util/ResponseConverter.js
+++ b/src/service/Session/util/ResponseConverter.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const ProtoDataType = require("../../../../client-nodejs-proto/session/Concept_pb").AttributeType.DATA_TYPE;
+const ProtoDataType = require("../../../../grpc/nodejs/protocol/session/Concept_pb").AttributeType.DATA_TYPE;
 
 /**
  * This is used to parse gRPC responses and build type of Concepts or Iterators

--- a/src/service/Session/util/ResponseConverter.js
+++ b/src/service/Session/util/ResponseConverter.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-const ProtoDataType = require("../../../../client-nodejs-proto/protocol/session/Concept_pb").AttributeType.DATA_TYPE;
+const ProtoDataType = require("../../../../client-nodejs-proto/session/Concept_pb").AttributeType.DATA_TYPE;
 
 /**
  * This is used to parse gRPC responses and build type of Concepts or Iterators


### PR DESCRIPTION
## What is the goal of this PR?

Recent splitting `protocol` out of Grakn Core to a separate repo broke dependency between `client-nodejs` and `protocol`. This PR makes it possible to build `grakn-client` (Grakn Client NodeJS) with dependency on `protocol` in a separate repo ([`graknlabs/protocol`](http://github.com/graknlabs/protocol)) 

## What are the changes implemented in this PR?

- Introduce a dependency on `@graknlabs_protocol`
- Use new `assemble_npm`/`new_deploy_npm` rules to build and deploy to NPM

