### PR TITLE
Use renamed rule from @graknlabs_bazel_distribution

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -24,7 +24,7 @@ exports_files([
 ])
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package", "nodejs_jest_test", "babel_library")
-load("@graknlabs_bazel_distribution//npm:rules.bzl", "assemble_npm", "new_deploy_npm")
+load("@graknlabs_bazel_distribution//npm:rules.bzl", "assemble_npm", "deploy_npm")
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 
 
@@ -67,7 +67,7 @@ assemble_npm(
     version_file = "//:VERSION",
 )
 
-new_deploy_npm(
+deploy_npm(
     name = "deploy-npm",
     target = ":assemble-npm",
     deployment_properties = "@graknlabs_build_tools//:deployment.properties",


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/bazel-distribution#155 renamed `new_deploy_npm` to `deploy_npm` to have consistent naming. This PR utilizes new renamed rule.

## What are the changes implemented in this PR?

Use `deploy_npm` in place of `new_deploy_npm`
