### PR TITLE
Supply authentication credentials for keyspace operations

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,12 +29,12 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "e68b03e886986846346a260346bd6743ab967f2e" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "c92c602ff4d299ce7ccf688affcf18c41f840cb9" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "dbbea5ae6870dc0624658091c221fe9fc292bad1" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "887409713c38deeebbdae01fa00946097887d20c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )

--- a/src/service/Keyspace/KeyspaceService.js
+++ b/src/service/Keyspace/KeyspaceService.js
@@ -26,10 +26,8 @@ function KeyspaceService(grpcClient, credentials) {
 
 KeyspaceService.prototype.retrieve = function () {
     const retrieveRequest = new messages.Keyspace.Retrieve.Req();
-    if (this.credentials.username !== undefined) {
+    if (this.credentials) {
         retrieveRequest.setUsername(this.credentials.username);
-    }
-    if (this.credentials.password !== undefined) {
         retrieveRequest.setPassword(this.credentials.password);
     }
     return new Promise((resolve, reject) => {
@@ -43,10 +41,8 @@ KeyspaceService.prototype.retrieve = function () {
 KeyspaceService.prototype.delete = function (keyspace) {
     const deleteRequest = new messages.Keyspace.Delete.Req();
     deleteRequest.setName(keyspace);
-    if (this.credentials.username !== undefined) {
+    if (this.credentials) {
         deleteRequest.setUsername(this.credentials.username);
-    }
-    if (this.credentials.password !== undefined) {
         deleteRequest.setPassword(this.credentials.password);
     }
     return new Promise((resolve, reject) => {

--- a/src/service/Keyspace/KeyspaceService.js
+++ b/src/service/Keyspace/KeyspaceService.js
@@ -26,6 +26,12 @@ function KeyspaceService(grpcClient, credentials) {
 
 KeyspaceService.prototype.retrieve = function () {
     const retrieveRequest = new messages.Keyspace.Retrieve.Req();
+    if (this.credentials.username !== undefined) {
+        retrieveRequest.setUsername(this.credentials.username);
+    }
+    if (this.credentials.password !== undefined) {
+        retrieveRequest.setPassword(this.credentials.password);
+    }
     return new Promise((resolve, reject) => {
         this.client.retrieve(retrieveRequest, (err, resp) => {
             if (err) reject(err);
@@ -37,6 +43,12 @@ KeyspaceService.prototype.retrieve = function () {
 KeyspaceService.prototype.delete = function (keyspace) {
     const deleteRequest = new messages.Keyspace.Delete.Req();
     deleteRequest.setName(keyspace);
+    if (this.credentials.username !== undefined) {
+        deleteRequest.setUsername(this.credentials.username);
+    }
+    if (this.credentials.password !== undefined) {
+        deleteRequest.setPassword(this.credentials.password);
+    }
     return new Promise((resolve, reject) => {
         this.client.delete(deleteRequest, (err) => {
             if (err) reject(err);


### PR DESCRIPTION
## What is the goal of this PR?

Recent changes in protocol (graknlabs/protocol#7) allow keyspace operations to be authenticated. This PR adapts Grakn Client NodeJS to these recent changes.

## What are the changes implemented in this PR?

- `KeyspaceService.retrieve` and `KeyspaceService.delete` now properly set credentials
- Bump `@graknlabs_protocol` and `@graknlabs_grakn_core` to latest version