### PR TITLE
Use release-validate-deps to ensure that client-nodejs depends on a released version of protocol

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
     working_directory: ~/client-nodejs
     steps:
       - checkout
-      - run: git push --delete origin client-nodejs-release-branch
+      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/client-nodejs $CIRCLE_BRANCH
 
 workflows:
   client-nodejs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,15 @@ jobs:
           export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:release-approval
 
+  release-validate:
+    machine: true
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: |
+          bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
+            graknlabs_common graknlabs_console graknlabs_graql graknlabs_protocol
+
   deploy-github:
     machine: true
     working_directory: ~/client-nodejs
@@ -198,10 +207,16 @@ workflows:
 
   client-nodejs-release:
     jobs:
+      - release-validate:
+          filters:
+            branches:
+              only: client-nodejs-release-branch
       - deploy-github:
           filters:
             branches:
               only: client-nodejs-release-branch
+          requires:
+            - release-validate
       - deploy-approval:
           type: approval
           requires:


### PR DESCRIPTION
## What is the goal of this PR?

We have added a validation step using `//ci:release-validate-deps` in order to ensure that client-nodejs is releasable only if it depends on a released version of protocol