### PR TITLE
Fix bazel build strategies

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,10 +18,6 @@ build:rbe --remote_timeout=3600
 build:rbe --bes_timeout=60s
 build:rbe --tls_enabled=true
 build:rbe --auth_enabled=true
-build:rbe --spawn_strategy=remote
-build:rbe --strategy=Javac=remote
-build:rbe --strategy=Closure=remote
-build:rbe --genrule_strategy=remote
 build:rbe --define=EXECUTOR=remote
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true


### PR DESCRIPTION
## What is the goal of this PR?

Fix CI build by allowing certain actions (`npm pack`, `npm publish`) to be executed non-remotely

## What are the changes implemented in this PR?

Starting from `0.27`, `bazel` automatically picks us `remote` strategy if it's available for action (see bazelbuild/bazel#7480 for details). However, setting `--spawn_strategy` explicitly prohibits `bazel` from using _any_ other strategy (such as `local`) — which is needed for executing `npm pack`/`npm publish` in `assemble_npm` and `deploy_npm`, respectively.
