### PR TITLE
Upgrade @graknlabs_build_tools to fix CI

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "04c69fbe5277bf2ed9e2baf5e9a53ac3c9ebee80", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "2706424f99bab0b93d41a419cce58e4db5d76527", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():


### PR DESCRIPTION
## What is the goal of this PR?

`sync-dependencies-snapshot` CI job is not working because `build-tools` is not up-to-date enough where it has been fixed already.

## What are the changes implemented in this PR?

Upgrade `@graknlabs_build_tools` to latest `master`
