### PR TITLE
Refactor how version is provided to deployment rule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           export DEPLOY_NPM_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_NPM_PASSWORD=$REPO_GRAKN_PASSWORD
           export DEPLOY_NPM_EMAIL=$REPO_GRAKN_EMAIL
-          bazel run //:deploy-npm -- snapshot
+          bazel run --define version=$(git rev-parse HEAD) //:deploy-npm -- snapshot
 
   test-deployment:
     machine: true
@@ -147,7 +147,7 @@ jobs:
           export DEPLOY_NPM_USERNAME=$REPO_NPM_USERNAME
           export DEPLOY_NPM_PASSWORD=$REPO_NPM_PASSWORD
           export DEPLOY_NPM_EMAIL=$REPO_NPM_EMAIL
-          bazel run //:deploy-npm -- release
+          bazel run --define version=$(cat VERSION) //:deploy-npm -- release
 
   sync-dependencies-release:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -57,7 +57,6 @@ npm_package(
 assemble_npm(
     name = "assemble-npm",
     target = ":client-nodejs",
-    version_file = "//:VERSION",
 )
 
 deploy_npm(

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "a898bbb0d88932409addbba2a18846ddaaf18f91", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "fd5991143dc2d7a0db895e2588688313005882d6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/bazel-distribution#193 changes how version should be provided

## What are the changes implemented in this PR?

* provide version as argument to `bazel`
* upgrade `@graknlabs_build_tools`
