### PR TITLE
Use updated versioning scheme for snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           nvm install v10.15.3
           nvm use --delete-prefix v10.15.3
           cd tests/deployment/
-          echo -n "$(cat ../../VERSION)-$CIRCLE_SHA1" > ../../VERSION
+          echo -n "0.0.0-$CIRCLE_SHA1" > ../../VERSION
           npm install https://repo.grakn.ai/repository/npm-snapshot-group/grakn-client/-/grakn-client-$(cat ../../VERSION).tgz
           npm install jest --global
           jest --detectOpenHandles application.test.js


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/client-nodejs#59 updated versioning scheme for snapshot deployments such that they are now named `0.0.0-{commit}` instead of `{version}-{commit}`. This PR adapts `test-deployment` CI job to these changes

## What are the changes implemented in this PR?

Use `0.0.0` in place of version file when determining a version of `grakn-client` to test
