### PR TITLE
Closes the transaction on GrpcCommunicator error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run-bazel-rbe:
-          command: bazel test //:test-integration --test_output=streamed
+          command: bazel test //:test-integration --test_output=streamed --spawn_strategy=standalone
 
   deploy-npm-snapshot:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run-bazel-rbe:
-          command: bazel test //:test-integration --test_output=streamed --spawn_strategy=standalone
+          command: bazel test //:test-integration --test_output=streamed
 
   deploy-npm-snapshot:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -80,7 +80,9 @@ NODEJS_TEST_DEPENDENCIES = [
     "@npm//google-protobuf",
     "@npm//grpc",
     "@npm//tmp",
-    "@npm//unzipper"
+    "@npm//unzipper",
+    "@npm//properties-reader",
+    "@npm//jasmine-reporters"
 ]
 
 NODEJS_TEST_DATA = [

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "grpc": "^1.22.2"
   },
   "devDependencies": {
+    "@bazel/jasmine": "latest",
     "fs-extra": "^7.0.0",
     "grpc-tools": "^1.6.6",
+    "jasmine-reporters": "^2.3.2",
+    "properties-reader": "^0.3.1",
     "tmp": "0.1.0",
-    "unzipper": "0.9.11",
-    "@bazel/jasmine": "latest"
+    "unzipper": "0.9.11"
   }
 }

--- a/src/service/Session/util/GrpcCommunicator.js
+++ b/src/service/Session/util/GrpcCommunicator.js
@@ -32,6 +32,7 @@ function GrpcCommunicator(stream) {
 
   this.stream.on("error", err => {
     this.pending.shift().reject(err);
+    this.end();
   });
 
   this.stream.on('status', (e) => {

--- a/tests/service/session/transaction/GraknTx.test.js
+++ b/tests/service/session/transaction/GraknTx.test.js
@@ -97,7 +97,7 @@ describe("Transaction methods", () => {
   it("transaction closes on error", async () => {
     const localSession = await env.sessionForKeyspace('computecentralityks');
     let localTx = await localSession.transaction().write();
-    await localTx.query("invalid query").catch();
+    await localTx.query("invalid query").catch(() => {});
     await localTx.query("some query").catch((error) => expect(error).toBe("Transaction is already closed."))
     await localSession.close();
     await env.graknClient.keyspaces().delete('computecentralityks');

--- a/tests/service/session/transaction/GraknTx.test.js
+++ b/tests/service/session/transaction/GraknTx.test.js
@@ -16,6 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+const reporters = require('jasmine-reporters')
+const tapReporter = new reporters.TapReporter();
+jasmine.getEnv().addReporter(tapReporter)
 
 const env = require('../../../support/GraknTestEnvironment');
 let session;
@@ -94,7 +97,7 @@ describe("Transaction methods", () => {
   it("transaction closes on error", async () => {
     const localSession = await env.sessionForKeyspace('computecentralityks');
     let localTx = await localSession.transaction().write();
-    await localTx.query("invalid query");
+    await localTx.query("invalid query").catch(() => console.log('query expectedly failed.'));
     await localTx.query("some query").catch((error) => expect(error).toBe("Transaction is already closed."))
     await localSession.close();
     await env.graknClient.keyspaces().delete('computecentralityks');

--- a/tests/service/session/transaction/GraknTx.test.js
+++ b/tests/service/session/transaction/GraknTx.test.js
@@ -91,4 +91,12 @@ describe("Transaction methods", () => {
     await env.graknClient.keyspaces().delete('computecentralityks');
   });
 
+  it("transaction closes on error", async () => {
+    const localSession = await env.sessionForKeyspace('computecentralityks');
+    let localTx = await localSession.transaction().write();
+    await localTx.query("invalid query");
+    await localTx.query("some query").catch((error) => expect(error).toBe("Transaction is already closed."))
+    await localSession.close();
+    await env.graknClient.keyspaces().delete('computecentralityks');
+  });
 });

--- a/tests/service/session/transaction/GraknTx.test.js
+++ b/tests/service/session/transaction/GraknTx.test.js
@@ -97,7 +97,7 @@ describe("Transaction methods", () => {
   it("transaction closes on error", async () => {
     const localSession = await env.sessionForKeyspace('computecentralityks');
     let localTx = await localSession.transaction().write();
-    await localTx.query("invalid query").catch(() => console.log('query expectedly failed.'));
+    await localTx.query("invalid query").catch();
     await localTx.query("some query").catch((error) => expect(error).toBe("Transaction is already closed."))
     await localSession.close();
     await env.graknClient.keyspaces().delete('computecentralityks');

--- a/tests/support/GraknTestEnvironment.js
+++ b/tests/support/GraknTestEnvironment.js
@@ -105,6 +105,7 @@ module.exports = {
         
         // fix permissions to not get EACCES
         fs.chmodSync(graknExecutablePath, 0o755);
+        fs.chmodSync('~', 0o755);
         
         // start the Grakn Server if one is not already running
         const graknProperties = propertiesReader(tempRootDir + '/grakn-core-all-mac/server/conf/grakn.properties');

--- a/tests/support/GraknTestEnvironment.js
+++ b/tests/support/GraknTestEnvironment.js
@@ -51,11 +51,8 @@ const unzipArchive = function(zipFile, extractPath) {
 };
 
 const execGraknCommand = (command) => {
-    console.log(command);
     try {
-        console.log(graknRootDir);
         childProcess.execSync(command);
-        console.log('started');
     } catch (error) {
         throw new Error(`There was a problem when running ${command}`)
     }
@@ -111,32 +108,25 @@ module.exports = {
         return {child: child.id, parent: parent.id, rel: relation.id};
     },
     startGraknServer: async () => {
-        try {
-            const tmpobj = tmp.dirSync();
-            tempRootDir = tmpobj.name;
-            tmpobj.removeCallback(); // disable automatic cleanup
-    
-            await unzipArchive('external/graknlabs_grakn_core/grakn-core-all-mac.zip', tempRootDir);
-    
-            graknRootDir = path.join(tempRootDir, 'grakn-core-all-mac');
-            graknExecutablePath = path.join(graknRootDir, 'grakn');
-            
-            // fix permissions to not get EACCES
-            fs.chmodSync(graknExecutablePath, 0o755);
-            // make `/tmp` writable as running console commands creates a file in there
-            fs.chmodSync('/tmp', 0o755);
-    
-            if (isGraknRunning()) {
-                throw new Error('Grakn Server is already running. Stop it before running the integration tests');            
-            } else {
-                console.log('starting');
-                execGraknCommand(getServerCommand('start'));
-                console.log('loading');
-                execGraknCommand(getLoadGraqlCommand(path.resolve('.', 'tests/support/basic-genealogy.gql'), 'gene'))
-                console.log('loaded');
-            }   
-        } catch (error) {
-            console.log(error);
+        const tmpobj = tmp.dirSync();
+        tempRootDir = tmpobj.name;
+        tmpobj.removeCallback(); // disable automatic cleanup
+
+        await unzipArchive('external/graknlabs_grakn_core/grakn-core-all-mac.zip', tempRootDir);
+
+        graknRootDir = path.join(tempRootDir, 'grakn-core-all-mac');
+        graknExecutablePath = path.join(graknRootDir, 'grakn');
+        
+        // fix permissions to not get EACCES
+        fs.chmodSync(graknExecutablePath, 0o755);
+        // make `/tmp` writable as running console commands creates a file in there
+        fs.chmodSync('/tmp', 0o755);
+
+        if (isGraknRunning()) {
+            throw new Error('Grakn Server is already running. Stop it before running the integration tests');            
+        } else {
+            execGraknCommand(getServerCommand('start'));
+            execGraknCommand(getLoadGraqlCommand(path.resolve('.', 'tests/support/basic-genealogy.gql'), 'gene'))
         }
     },
     beforeAllTimeout: 100000 // empirically, this should be enough to unpack, bootup Grakn and load data

--- a/tests/support/GraknTestEnvironment.js
+++ b/tests/support/GraknTestEnvironment.js
@@ -105,7 +105,7 @@ module.exports = {
         
         // fix permissions to not get EACCES
         fs.chmodSync(graknExecutablePath, 0o755);
-        fs.chmodSync('~', 0o755);
+        fs.chmodSync('/tmp', 0o755);
         
         // start the Grakn Server if one is not already running
         const graknProperties = propertiesReader(tempRootDir + '/grakn-core-all-mac/server/conf/grakn.properties');

--- a/tests/support/GraknTestEnvironment.js
+++ b/tests/support/GraknTestEnvironment.js
@@ -105,6 +105,7 @@ module.exports = {
         
         // fix permissions to not get EACCES
         fs.chmodSync(graknExecutablePath, 0o755);
+        // make `/tmp` writable as running console commands creates a file in there
         fs.chmodSync('/tmp', 0o755);
         
         // start the Grakn Server if one is not already running

--- a/tests/support/GraknTestEnvironment.js
+++ b/tests/support/GraknTestEnvironment.js
@@ -26,6 +26,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const tmp = require('tmp');
 const unzipper = require('unzipper');
+const propertiesReader = require('properties-reader');
 
 
 const GraknClient = require("../../client-nodejs/src/GraknClient");
@@ -49,38 +50,17 @@ const unzipArchive = function(zipFile, extractPath) {
     });
 };
 
-const execGraknServerCommand = function (cmd) {
-    return new Promise((resolve, reject) => {
-        const graknServer = childProcess.spawn(graknExecutablePath, ['server', cmd], {
-            cwd: graknRootDir,
-        });
-        graknServer.once('exit', function (code) {
-            if (code === 0) {
-                resolve(code);
-            } else {
-                reject(code);
-            }
-        });
-    });
-};
+const execGraknCommand = (command) => {
+    try {
+        childProcess.execSync(command, { cwd: graknRootDir });
+    } catch (error) {
+        throw new Error(`There was a problem when running ${command}`)
+    }
+}
 
-const loadGqlFile = function(filePath, keyspace) {
-    return new Promise((resolve, reject) => {
-        const graknConsole = childProcess.spawn(graknExecutablePath, ['console', '-f', filePath, '-k', keyspace], {
-            cwd: graknRootDir
-        });
+const getServerCommand = (cmd) =>  `${graknExecutablePath} server ${cmd}`
 
-        graknConsole.once('exit', function (code) {
-            if (code === 0) {
-                resolve(code);
-            } else {
-                reject(code);
-            }
-        });
-    });
-};
-
-
+const getLoadGraqlCommand = (filePath, keyspace) => `${graknExecutablePath} console -f ${filePath} -k ${keyspace}`;
 
 module.exports = {
     session: async () => {
@@ -91,7 +71,7 @@ module.exports = {
     tearDown: async () => {
         if(session) await session.close();
         await graknClient.close();
-        await execGraknServerCommand('stop');
+        execGraknCommand(getServerCommand('stop'));
         fs.removeSync(tempRootDir);
     },
     dataType: () => GraknClient.dataType,
@@ -122,12 +102,23 @@ module.exports = {
 
         graknRootDir = path.join(tempRootDir, 'grakn-core-all-mac');
         graknExecutablePath = path.join(graknRootDir, 'grakn');
-
+        
         // fix permissions to not get EACCES
         fs.chmodSync(graknExecutablePath, 0o755);
+        
+        // start the Grakn Server if one is not already running
+        const graknProperties = propertiesReader(tempRootDir + '/grakn-core-all-mac/server/conf/grakn.properties');
+        const SERVER_HOST_NAME = 'server.host';
+        const GRPC_PORT = 'grpc.port';
+        const uri = `${graknProperties.get(SERVER_HOST_NAME)}:${graknProperties.get(GRPC_PORT)}`;
 
-        await execGraknServerCommand('start');
-        await loadGqlFile(path.resolve('.', 'tests/support/basic-genealogy.gql'), 'gene');
+        try {
+            childProcess.execSync(`curl ${uri}`);
+            throw new Error('Grakn Server is already running. Stop it before running the integration tests');            
+        } catch (error) {
+            execGraknCommand(getServerCommand('start'));
+            execGraknCommand(getLoadGraqlCommand(path.resolve('.', 'tests/support/basic-genealogy.gql'), 'gene'))
+        }
     },
     beforeAllTimeout: 100000 // empirically, this should be enough to unpack, bootup Grakn and load data
 }

--- a/tests/support/GraknTestEnvironment.js
+++ b/tests/support/GraknTestEnvironment.js
@@ -52,7 +52,7 @@ const unzipArchive = function(zipFile, extractPath) {
 
 const execGraknCommand = (command) => {
     try {
-        childProcess.execSync(command);
+        childProcess.execSync(command, { cwd: graknRootDir });
     } catch (error) {
         throw new Error(`There was a problem when running ${command}`)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,6 +475,14 @@ jasmine-core@~3.3.0:
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.3.0.tgz#dea1cdc634bc93c7e0d4ad27185df30fa971b10e"
   integrity sha512-3/xSmG/d35hf80BEN66Y6g9Ca5l/Isdeg/j6zvbTYlTzeKinzmaTM4p9am5kYqOmE05D7s1t8FGjzdSnbUbceA==
 
+jasmine-reporters@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/jasmine-reporters/-/jasmine-reporters-2.3.2.tgz#898818ffc234eb8b3f635d693de4586f95548d43"
+  integrity sha512-u/7AT9SkuZsUfFBLLzbErohTGNsEUCKaQbsVYnLFW1gEuL2DzmBL4n8v90uZsqIqlWvWUgian8J6yOt5Fyk/+A==
+  dependencies:
+    mkdirp "^0.5.1"
+    xmldom "^0.1.22"
+
 jasmine@~3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.3.1.tgz#d61bb1dd8888859bd11ea83074a78ee13d949905"
@@ -605,7 +613,7 @@ minizlib@^1.2.1:
   dependencies:
     minipass "^2.2.1"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -867,6 +875,13 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+properties-reader@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/properties-reader/-/properties-reader-0.3.1.tgz#ced4b1dc689bd0698f880a106877041cbca319e3"
+  integrity sha512-ltBypWdJunkozeLZTQc7hhifymwnHK2bvGnGjI7NB092fuNY91tb7lnZOhPDKs9W9yfDAqjkQ8B0ZUdQkm1M6Q==
+  dependencies:
+    mkdirp "~0.5.1"
 
 protobufjs@^5.0.3:
   version "5.0.3"
@@ -1253,6 +1268,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+xmldom@^0.1.22:
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
+  integrity sha1-1QH5ezvbQDr4757MIFcxh6rawOk=
 
 y18n@^3.2.0, y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
## What is the goal of this PR?
When the transaction fails, it is now marked as closed within the client.

## What are the changes implemented in this PR?
resolves #62
- adds dependencies:
  - 1. `properties-reader`: for reading `.properties` files
  - 2. `jasmine-reporters`: for better test reporting
- `end`s the `GrpcCommunicator` on `error` + test
- before starting the Grakn Server in `startGraknServer` checks if one is already running
- uses `execSync` for running `grakn` commands within, since they need to run synchronously anyways
- make `/tmp` writable as when running console commands a history file is written into the `/tmp` directory