### PR TITLE
Provides a function for checking if transaction is open

### DIFF
--- a/src/Transaction.js
+++ b/src/Transaction.js
@@ -85,4 +85,8 @@ Transaction.prototype.close = function () {
     return this.txService.close();
 }
 
+Transaction.prototype.isOpen = function () {
+    return this.txService.isOpen();
+}
+
 module.exports = Transaction;

--- a/src/service/Session/TransactionService.js
+++ b/src/service/Session/TransactionService.js
@@ -46,6 +46,10 @@ TransactionService.prototype.close = function () {
     return this.communicator.end();
 }
 
+TransactionService.prototype.isOpen = function () {
+    return this.communicator.stream.writable;
+};
+
 // Concept
 TransactionService.prototype.deleteConcept = function (id) {
     const txRequest = RequestBuilder.deleteConcept(id);

--- a/tests/service/session/transaction/GraknTx.test.js
+++ b/tests/service/session/transaction/GraknTx.test.js
@@ -98,7 +98,17 @@ describe("Transaction methods", () => {
     const localSession = await env.sessionForKeyspace('computecentralityks');
     let localTx = await localSession.transaction().write();
     await localTx.query("invalid query").catch(() => {});
-    await localTx.query("some query").catch((error) => expect(error).toBe("Transaction is already closed."))
+    expect(localTx.isOpen()).toBe(false);
+    await localSession.close();
+    await env.graknClient.keyspaces().delete('computecentralityks');
+  });
+
+  it("transaction isOpen", async () => {
+    const localSession = await env.sessionForKeyspace('computecentralityks');
+    const localTx = await localSession.transaction().write();
+    expect(localTx.isOpen()).toEqual(true);
+    await localTx.close();
+    expect(localTx.isOpen()).toEqual(false);
     await localSession.close();
     await env.graknClient.keyspaces().delete('computecentralityks');
   });


### PR DESCRIPTION
## What is the goal of this PR?
`isOpen()` may now be called on the transaction object to determine whether the transaction is still open.

## What are the changes implemented in this PR?
- adds `isOpen()` to `Transaction.js` and `TransactionService.js`
- adds an integration test to test the functionality of `isOpen()`
- modifies the `transaction closes on error` integration test to use the newly added `isOpen()`