### PR TITLE
Delete Queries return Void Answer Type

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -231,6 +231,16 @@ jasmine_node_test(
     data = NODEJS_TEST_DATA,
 )
 
+jasmine_node_test(
+    name = "query-test",
+    srcs = [
+        "tests/support/GraknTestEnvironment.js",
+        "tests/service/session/transaction/Query.test.js",
+    ],
+    deps = NODEJS_TEST_DEPENDENCIES,
+    data = NODEJS_TEST_DATA,
+)
+
 test_suite(
     name = "test-integration",
     tests = [
@@ -248,5 +258,6 @@ test_suite(
         ":thing-test",
         ":entitytype-test",
         ":committx-test",
+        ":query-test",
     ]
 )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,7 +29,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "50ced0fada14e4a2fda49d212d83f335d02dd0ca" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "14869e195f439f5dba20ad013524287319edb5b6" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/src/service/Session/util/AnswerFactory.js
+++ b/src/service/Session/util/AnswerFactory.js
@@ -26,12 +26,14 @@ function AnswerFactory(conceptFactory) {
 }
 
 AnswerFactory.prototype.createAnswer = function (grpcAnswer) {
+    debugger;
     if (grpcAnswer.hasConceptmap()) return this.createConceptmap(grpcAnswer.getConceptmap());
     if (grpcAnswer.hasAnswergroup()) return this.createAnswergroup(grpcAnswer.getAnswergroup());
     if (grpcAnswer.hasConceptlist()) return this.createConceptlist(grpcAnswer.getConceptlist());
     if (grpcAnswer.hasConceptset()) return this.createConceptset(grpcAnswer.getConceptset());
     if (grpcAnswer.hasConceptsetmeasure()) return this.createConceptsetmeasure(grpcAnswer.getConceptsetmeasure());
     if (grpcAnswer.hasValue()) return this.createValue(grpcAnswer.getValue());
+    if (grpcAnswer.hasVoid()) return null;
 }
 
 AnswerFactory.prototype.buildExplanation = function (grpcExplanation) {

--- a/src/service/Session/util/AnswerFactory.js
+++ b/src/service/Session/util/AnswerFactory.js
@@ -26,14 +26,13 @@ function AnswerFactory(conceptFactory) {
 }
 
 AnswerFactory.prototype.createAnswer = function (grpcAnswer) {
-    debugger;
     if (grpcAnswer.hasConceptmap()) return this.createConceptmap(grpcAnswer.getConceptmap());
     if (grpcAnswer.hasAnswergroup()) return this.createAnswergroup(grpcAnswer.getAnswergroup());
     if (grpcAnswer.hasConceptlist()) return this.createConceptlist(grpcAnswer.getConceptlist());
     if (grpcAnswer.hasConceptset()) return this.createConceptset(grpcAnswer.getConceptset());
     if (grpcAnswer.hasConceptsetmeasure()) return this.createConceptsetmeasure(grpcAnswer.getConceptsetmeasure());
     if (grpcAnswer.hasValue()) return this.createValue(grpcAnswer.getValue());
-    if (grpcAnswer.hasVoid()) return null;
+    if (grpcAnswer.hasVoid()) return this.createVoid(grpcAnswer.getVoid());
 }
 
 AnswerFactory.prototype.buildExplanation = function (grpcExplanation) {
@@ -87,6 +86,12 @@ AnswerFactory.prototype.createAnswergroup = function(answer){
         owner: () => this.conceptFactory.createConcept(answer.getOwner()),
         answers: () => answer.getAnswersList().map(a => this.createAnswer(a)),
         explanation: () => this.buildExplanation(answer.getExplanation())
+    }
+}
+
+AnswerFactory.prototype.createVoid = function(answer){
+    return {
+        message: () => answer.getMessage()
     }
 }
 

--- a/tests/service/session/transaction/Query.test.js
+++ b/tests/service/session/transaction/Query.test.js
@@ -41,7 +41,7 @@ afterEach(() => {
   tx.close();
 });
 
-describe("Transaction methods", () => {
+describe("Query methods", () => {
   it("delete query response type should be Void", async () => {
     const localSession = await env.sessionForKeyspace('gene');
     let localTx = await localSession.transaction().write();

--- a/tests/service/session/transaction/Query.test.js
+++ b/tests/service/session/transaction/Query.test.js
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+const reporters = require('jasmine-reporters')
+const tapReporter = new reporters.TapReporter();
+jasmine.getEnv().addReporter(tapReporter)
+
+const env = require('../../../support/GraknTestEnvironment');
+let session;
+let tx;
+
+beforeAll(async () => {
+  await env.startGraknServer();
+  session = await env.session();
+}, env.beforeAllTimeout);
+
+afterAll(async () => {
+  await env.tearDown();
+});
+
+beforeEach(async () => {
+  tx = await session.transaction().write();
+})
+
+afterEach(() => {
+  tx.close();
+});
+
+describe("Transaction methods", () => {
+  it("transaction closes on error", async () => {
+    const localSession = await env.sessionForKeyspace('gene');
+    let localTx = await localSession.transaction().write();
+    await localTx.query('insert $x isa person, has identifier "a";');
+    debugger;
+    const response = await (await localTx.query('match $x isa person, has identifier "a"; delete $x;')).collect();
+    expect(response).toBe(null);
+    await localTx.close();
+    await localSession.close();
+    await env.graknClient.keyspaces().delete('gene');
+  });
+});

--- a/tests/service/session/transaction/Query.test.js
+++ b/tests/service/session/transaction/Query.test.js
@@ -42,13 +42,13 @@ afterEach(() => {
 });
 
 describe("Transaction methods", () => {
-  it("transaction closes on error", async () => {
+  it("delete query response type should be Void", async () => {
     const localSession = await env.sessionForKeyspace('gene');
     let localTx = await localSession.transaction().write();
     await localTx.query('insert $x isa person, has identifier "a";');
-    debugger;
-    const response = await (await localTx.query('match $x isa person, has identifier "a"; delete $x;')).collect();
-    expect(response).toBe(null);
+    const iterator = await localTx.query('match $x isa person, has identifier "a"; delete $x;');
+    const response = await iterator.next();
+    expect(response.message()).toEqual("Delete successful.");
     await localTx.close();
     await localSession.close();
     await env.graknClient.keyspaces().delete('gene');


### PR DESCRIPTION
## What is the goal of this PR?
As of https://github.com/graknlabs/protocol/pull/18, we have decided in a slight paradigm shift with `delete` queries:

1. straight delete queries `match...; delete...;` only return a message rather than the halfway house of all deleted Concept IDs (this was always awkward, should either return a Concept -- hard because vertex deleted, or nothing. We have opted for nothing).
2. If you want to know what was deleted, this implies your behaviour was a _retrieve_ followed by a _delete_. This retrieve should be performed explicitly by the user not implicitly by Grakn, ie. a `match...; get...;` followed by `delete` using Concept API, or using a separate `match...; delete;` query.

## What are the changes implemented in this PR?
* Delete queries passed to the client now return `Void` answer type with a status message