### PR TITLE
isDeleted() is added to Concept

### DIFF
--- a/src/service/Session/concept/Methods.js
+++ b/src/service/Session/concept/Methods.js
@@ -36,6 +36,10 @@ const methods = {
     },
     concept: {
         delete: function () { return this.txService.deleteConcept(this.id); },
+        isDeleted: async function () {
+            const concept = await this.txService.getConcept(this.id);
+            return concept === null;
+        },
         isSchemaConcept: function () { return Constant.set.SCHEMA_CONCEPTS.has(this.baseType); },
         isType: function () { return Constant.set.TYPES.has(this.baseType); },
         isThing: function () { return Constant.set.THINGS.has(this.baseType); },

--- a/tests/service/session/transaction/Concept.test.js
+++ b/tests/service/session/transaction/Concept.test.js
@@ -205,4 +205,17 @@ describe("Concept methods", () => {
         const bondAttributes = await (await tx.getAttributesByValue('Bond', env.dataType().STRING)).collect();
         expect(bondAttributes.length).toBe(0);
     });
+
+    it("isDeleted", async () => {
+        const personType = await tx.putEntityType('person');
+        const personOne = await personType.create();
+        expect(await personOne.isDeleted()).toEqual(false);
+
+        await personOne.delete();
+        expect(await personOne.isDeleted()).toEqual(true);
+
+        const personTwo = await personType.create();
+        await tx.query("match $x isa person; delete $x;");
+        expect(await personTwo.isDeleted()).toEqual(true);
+    });
 });


### PR DESCRIPTION
## What is the goal of this PR?
The isDeleted() method is now available on a Concept to check if it has been deleted.

## What are the changes implemented in this PR?
- adds `isDeleted()` to `methods.concept`
- adds `isDeleted` test to `tests/service/session/transaction/Concept.test.js`