### PR TITLE
Remove the release-validate job from the release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,15 +112,6 @@ jobs:
           export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:release-approval
 
-  release-validate:
-    machine: true
-    steps:
-      - install-bazel-linux-rbe
-      - checkout
-      - run: |
-          bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
-            graknlabs_common graknlabs_console graknlabs_graql graknlabs_protocol
-
   deploy-github:
     machine: true
     working_directory: ~/client-nodejs
@@ -207,16 +198,10 @@ workflows:
 
   client-nodejs-release:
     jobs:
-      - release-validate:
-          filters:
-            branches:
-              only: client-nodejs-release-branch
       - deploy-github:
           filters:
             branches:
               only: client-nodejs-release-branch
-          requires:
-            - release-validate
       - deploy-approval:
           type: approval
           requires:


### PR DESCRIPTION
## What is the goal of this PR?
At the moment, the release of Client Node.js does not need to be validated. The related job has been removed from the `release` workflow, for this reason.