### PR TITLE
close() on transaction checks if transaction is already closed

### DIFF
--- a/src/service/Session/util/GrpcCommunicator.js
+++ b/src/service/Session/util/GrpcCommunicator.js
@@ -40,7 +40,7 @@ function GrpcCommunicator(stream) {
   })
 }
 
-GrpcCommunicator.prototype.send = async function (request) {
+GrpcCommunicator.prototype.send = function (request) {
   if(!this.stream.writable) throw "Transaction is already closed.";
   return new Promise((resolve, reject) => {
     this.pending.push({ resolve, reject });
@@ -48,7 +48,7 @@ GrpcCommunicator.prototype.send = async function (request) {
   })
 };
 
-GrpcCommunicator.prototype.end = async function end() {
+GrpcCommunicator.prototype.end = function end() {
   if(this.stream.writable) { // transaction is still open
     this.stream.end();
     return new Promise((resolve) => {

--- a/src/service/Session/util/GrpcCommunicator.js
+++ b/src/service/Session/util/GrpcCommunicator.js
@@ -48,7 +48,8 @@ GrpcCommunicator.prototype.send = async function (request) {
   })
 };
 
-GrpcCommunicator.prototype.end = function end() {
+GrpcCommunicator.prototype.end = async function end() {
+  if(!this.stream.writable) throw "Transaction is already closed.";
   this.stream.end();
   return new Promise((resolve) => {
     this.stream.on('end', resolve);

--- a/src/service/Session/util/GrpcCommunicator.js
+++ b/src/service/Session/util/GrpcCommunicator.js
@@ -49,11 +49,12 @@ GrpcCommunicator.prototype.send = async function (request) {
 };
 
 GrpcCommunicator.prototype.end = async function end() {
-  if(!this.stream.writable) throw "Transaction is already closed.";
-  this.stream.end();
-  return new Promise((resolve) => {
-    this.stream.on('end', resolve);
-  });
+  if(this.stream.writable) { // transaction is still open
+    this.stream.end();
+    return new Promise((resolve) => {
+      this.stream.on('end', resolve);
+    });
+  }
 }
 
 module.exports = GrpcCommunicator;

--- a/tests/service/session/transaction/GraknTx.test.js
+++ b/tests/service/session/transaction/GraknTx.test.js
@@ -117,7 +117,8 @@ describe("Transaction methods", () => {
     const localSession = await env.sessionForKeyspace('computecentralityks');
     const localTx = await localSession.transaction().read();
     await localTx.close();
-    await localTx.close().catch((error) => expect(error).toEqual("Transaction is already closed."));
+    await localTx.close();
+    expect(localTx.isOpen()).toEqual(false);
     await localSession.close();
     await env.graknClient.keyspaces().delete('computecentralityks');
   });

--- a/tests/service/session/transaction/GraknTx.test.js
+++ b/tests/service/session/transaction/GraknTx.test.js
@@ -112,4 +112,13 @@ describe("Transaction methods", () => {
     await localSession.close();
     await env.graknClient.keyspaces().delete('computecentralityks');
   });
+
+  it("closes transaction twice", async () => {
+    const localSession = await env.sessionForKeyspace('computecentralityks');
+    const localTx = await localSession.transaction().read();
+    await localTx.close();
+    await localTx.close().catch((error) => expect(error).toEqual("Transaction is already closed."));
+    await localSession.close();
+    await env.graknClient.keyspaces().delete('computecentralityks');
+  });
 });


### PR DESCRIPTION
## What is the goal of this PR?

Previously, when closing a transaction that had already been closed, the `.close()` call would stall. This bug has been fixed and now upon every call to `close()` on a transaction, a check is first made to ensure the transaction is still open before proceeding to close it.

## What are the changes implemented in this PR?
- in `GrpcCommunicator.prototype.end`, the implementation for closing the transaction is only executed if the transaction is still open.
resolves #36 