### PR TITLE
Handle error received without client request

### DIFF
--- a/src/service/Session/util/GrpcCommunicator.js
+++ b/src/service/Session/util/GrpcCommunicator.js
@@ -31,12 +31,18 @@ function GrpcCommunicator(stream) {
   });
 
   this.stream.on("error", err => {
-    this.pending.shift().reject(err);
     this.end();
+    if (this.pending.length) {
+      this.pending.shift().reject(err);
+    } else {
+      throw err;
+    }
   });
 
   this.stream.on('status', (e) => {
-    if (this.pending.length) this.pending.shift().reject(e);
+    if (this.pending.length) {
+      this.pending.shift().reject(e);
+    }
   })
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

We had a bug which lead to:
```
this.pending.shift().reject(err);
                        ^

TypeError: Cannot read property 'reject' of undefined
```

This happens when we receive an exception from the server that is not related to a request sent by the client, e.g. if the connection closes or the server crashes for other reason.

## What are the changes implemented in this PR?

Handle the above by just re-throwing the exception without trying to reject a pending request that will not be in the queue.
