### PR TITLE
Retrievable Explanations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run-bazel-rbe:
-          command: bazel test //:test-integration --test_output=streamed
+          command: bazel test //:test-integration --test_output=streamed --spawn_strategy=local
 
   deploy-npm-snapshot:
     machine: true

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,7 +29,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "02a583bebe718ad77f65db2e61cacc44b9b82cb3" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "2c184db846a93ced9f8349bcd59c16bb626375b7" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/src/service/Session/TransactionService.js
+++ b/src/service/Session/TransactionService.js
@@ -37,7 +37,7 @@ const GrpcIteratorFactory = require("./util/GrpcIteratorFactory");
 function TransactionService(txStream) {
     this.communicator = new GrpcCommunicator(txStream);
     const conceptFactory = new ConceptFactory(this);
-    const iteratorFactory = new GrpcIteratorFactory(conceptFactory, this.communicator);
+    const iteratorFactory = new GrpcIteratorFactory(conceptFactory, this);
     this.respConverter = new ResponseConverter(conceptFactory, iteratorFactory);
 }
 
@@ -364,6 +364,11 @@ TransactionService.prototype.query = function executeQuery(query, options) {
     const txRequest = RequestBuilder.executeQuery(query, options);
     return this.communicator.send(txRequest)
         .then(resp => this.respConverter.executeQuery(resp));
+};
+
+TransactionService.prototype.explanation = function (grpcConceptMap) {
+    const txRequest = RequestBuilder.explanation(grpcConceptMap);
+    return this.communicator.send(txRequest);
 };
 
 module.exports = TransactionService;

--- a/src/service/Session/util/AnswerFactory.js
+++ b/src/service/Session/util/AnswerFactory.js
@@ -36,7 +36,7 @@ AnswerFactory.prototype.createAnswer = function (grpcAnswer) {
 }
 
 AnswerFactory.prototype.buildExplanation = function (grpcExplanation) {
-    const grpcListOfConceptMaps = grpcExplanation.getExplanationsList();
+    const grpcListOfConceptMaps = grpcExplanation.getExplanationRes().getExplanationList();
     const nativeListOfConceptMaps = grpcListOfConceptMaps.map((grpcConceptMap) => this.createConceptmap(grpcConceptMap));
 
     return {
@@ -50,16 +50,17 @@ AnswerFactory.prototype.createConceptmap = function (answer) {
     answer.getMapMap().forEach((grpcConcept, key) => {
         answerMap.set(key, this.conceptFactory.createConcept(grpcConcept));
     });
-    
+
+
     return {
         map: () => answerMap,
         get: (v) => answerMap.get(v),
-        hasExplanation: () => answer.getHasExplanation(),
+        hasExplanation: () => answer.getHasexplanation(),
         queryPattern: () => answer.getPattern(),
-        explanation: () => {
-            if (answer.getHasExplanation()) {
-                const grpcExplanation = this.txService.explanation(answer.getMapMap());
-                return this.buildExplanation(grpcExplanation)
+        explanation: async () => {
+            if (answer.getHasexplanation()) {
+                const grpcExplanation = await this.txService.explanation(answer);
+                return this.buildExplanation(grpcExplanation);
             } else {
                 throw "Explanation not available on concept map";
             }

--- a/src/service/Session/util/AnswerFactory.js
+++ b/src/service/Session/util/AnswerFactory.js
@@ -21,8 +21,9 @@
  * Factory for Answer and Explanation objects
  * @param {Object} conceptFactory
  */
-function AnswerFactory(conceptFactory) {
+function AnswerFactory(conceptFactory, txService) {
     this.conceptFactory = conceptFactory;
+    this.txService = txService;
 }
 
 AnswerFactory.prototype.createAnswer = function (grpcAnswer) {
@@ -35,56 +36,63 @@ AnswerFactory.prototype.createAnswer = function (grpcAnswer) {
 }
 
 AnswerFactory.prototype.buildExplanation = function (grpcExplanation) {
-    if (!grpcExplanation) return null;
+    const grpcListOfConceptMaps = grpcExplanation.getExplanationsList();
+    const nativeListOfConceptMaps = grpcListOfConceptMaps.map((grpcConceptMap) => this.createConceptmap(grpcConceptMap));
+
     return {
-        queryPattern: () => grpcExplanation.getPattern(),
-        answers: () => grpcExplanation.getAnswersList().map(a => this.createConceptmap(a))
+        getAnswers: () => nativeListOfConceptMaps,
     }
 }
 
 AnswerFactory.prototype.createConceptmap = function (answer) {
     const answerMap = new Map();
+    
     answer.getMapMap().forEach((grpcConcept, key) => {
-            answerMap.set(key, this.conceptFactory.createConcept(grpcConcept));
-        });
+        answerMap.set(key, this.conceptFactory.createConcept(grpcConcept));
+    });
+    
     return {
         map: () => answerMap,
         get: (v) => answerMap.get(v),
-        explanation: () => this.buildExplanation(answer.getExplanation())
-    }
+        hasExplanation: () => answer.getHasExplanation(),
+        queryPattern: () => answer.getPattern(),
+        explanation: () => {
+            if (answer.getHasExplanation()) {
+                const grpcExplanation = this.txService.explanation(answer.getMapMap());
+                return this.buildExplanation(grpcExplanation)
+            } else {
+                throw "Explanation not available on concept map";
+            }
+        },
+    };
 }
 AnswerFactory.prototype.createValue = function(answer){
     return {
         number: () => Number(answer.getNumber().getValue()),
-        explanation: () => this.buildExplanation(answer.getExplanation())
     }
 }
 AnswerFactory.prototype.createConceptlist = function(answer){
     const list = answer.getList();
     return {
         list: () => list.getIdsList(),
-        explanation: () => this.buildExplanation(answer.getExplanation())
     }
 }
 AnswerFactory.prototype.createConceptset = function(answer){
     const set = answer.getSet();
     return {
         set: () => new Set(set.getIdsList()),
-        explanation: () => this.buildExplanation(answer.getExplanation())
     }
 }
 AnswerFactory.prototype.createConceptsetmeasure = function(answer){
     return {
         measurement: () => Number(answer.getMeasurement().getValue()),
         set: () => new Set(answer.getSet().getIdsList()),
-        explanation: () => this.buildExplanation(answer.getExplanation())
     }
 }
 AnswerFactory.prototype.createAnswergroup = function(answer){
     return {
         owner: () => this.conceptFactory.createConcept(answer.getOwner()),
         answers: () => answer.getAnswersList().map(a => this.createAnswer(a)),
-        explanation: () => this.buildExplanation(answer.getExplanation())
     }
 }
 

--- a/src/service/Session/util/GrpcCommunicator.js
+++ b/src/service/Session/util/GrpcCommunicator.js
@@ -51,6 +51,7 @@ GrpcCommunicator.prototype.send = function (request) {
   return new Promise((resolve, reject) => {
     this.pending.push({ resolve, reject });
     this.stream.write(request);
+
   })
 };
 

--- a/src/service/Session/util/GrpcIteratorFactory.js
+++ b/src/service/Session/util/GrpcIteratorFactory.js
@@ -23,10 +23,10 @@ const AnswerFactory = require("./AnswerFactory");
 /**
  * Factory of Iterators, bound to a specific transaction
  */
-function GrpcIteratorFactory(conceptFactory, communicator) {
-  this.communicator = communicator;
+function GrpcIteratorFactory(conceptFactory, txService) {
+  this.communicator = txService.communicator;
   this.conceptFactory = conceptFactory;
-  this.answerFactory = new AnswerFactory(conceptFactory);
+  this.answerFactory = new AnswerFactory(conceptFactory, txService);
 }
 
 // Query Iterator

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -536,6 +536,13 @@ const methods = {
     iterMessage.setId(iteratorId);
     txRequest.setIterateReq(iterMessage);
     return txRequest;
+  },
+  explanation: function (grpcConceptMap) {
+    const txRequest = new messages.Transaction.Req();
+    const explMessage = new messages.Transaction.Explanation.Req();
+    explMessage.setExplainable(grpcConceptMap);
+    txRequest.setExplanationReq(explMessage);
+    return txRequest;
   }
 
 };

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -18,6 +18,7 @@
  */
 
 const messages = require("../../../../grpc/nodejs/protocol/session/Session_pb");
+const answerMessages = require("../../../../grpc/nodejs/protocol/session/Answer_pb");
 const ConceptsBaseType = require("../concept/BaseTypeConstants").baseType;
 const ProtoDataType = require("../../../../grpc/nodejs/protocol/session/Concept_pb").AttributeType.DATA_TYPE;
 const INFER_TRUE_MESSAGE = messages.Transaction.Query.INFER.TRUE;
@@ -539,7 +540,7 @@ const methods = {
   },
   explanation: function (grpcConceptMap) {
     const txRequest = new messages.Transaction.Req();
-    const explMessage = new messages.Transaction.Explanation.Req();
+    const explMessage = new answerMessages.Explanation.Req();
     explMessage.setExplainable(grpcConceptMap);
     txRequest.setExplanationReq(explMessage);
     return txRequest;

--- a/tests/support/GraknTestEnvironment.js
+++ b/tests/support/GraknTestEnvironment.js
@@ -30,6 +30,7 @@ const propertiesReader = require('properties-reader');
 
 
 const GraknClient = require("../../client-nodejs/src/GraknClient");
+
 const graknClient = new GraknClient(DEFAULT_URI);
 
 let session;
@@ -126,7 +127,7 @@ module.exports = {
             throw new Error('Grakn Server is already running. Stop it before running the integration tests');            
         } else {
             execGraknCommand(getServerCommand('start'));
-            execGraknCommand(getLoadGraqlCommand(path.resolve('.', 'tests/support/basic-genealogy.gql'), 'gene'))
+            execGraknCommand(getLoadGraqlCommand(path.resolve('.', 'tests/support/basic-genealogy.gql'), 'gene'));
         }
     },
     beforeAllTimeout: 100000 // empirically, this should be enough to unpack, bootup Grakn and load data


### PR DESCRIPTION
## What is the goal of this PR?
As of https://github.com/graknlabs/grakn/pull/5483, Grakn Core now:
1. has retrievable explanation trees
2. only the `ConceptMap` answer type has `Explanation`
3. `pattern` has moved from `Explanation` to `ConceptMap`
4. `pattern` contains IDs for each variable as well as the query pattern

These changes are reflected in Client Node.js, as long with a `has_explanation()` method on `ConceptMap`.

## What are the changes implemented in this PR?
* `ConceptMap` contains `queryPattern()` and `hasExplanation()` methods
* `Explanation` no longer contains `queryPattern()` but only a list of `ConceptMap` via `getAnswers()`
* Utilises new gRPC messages to retrieve layers of the explanation tree
* Remove `Explanation` from any answers other than `ConceptMap`
* Refactor and add tests for `Answer` types, and restructure Answers