### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
     steps:
       - run-bazel-rbe:
           command: bazel build @graknlabs_grakn_core//:assemble-linux-targz
-      - run: mkdir dist && tar -xvzf bazel-genfiles/external/graknlabs_grakn_core/grakn-core-all-linux.tar.gz -C ./dist/
+      - run: mkdir dist && tar -xvzf bazel-bin/external/graknlabs_grakn_core/grakn-core-all-linux.tar.gz -C ./dist/
       - run: nohup ./dist/grakn-core-all-linux/grakn server start
 
 jobs:


### PR DESCRIPTION
## What is the goal of this PR?

CI is broken because `bazel-genfiles` is no longer symlinked by latest Bazel

## What are the changes implemented in this PR?

Use `bazel-bin` in place of `bazel-genfiles`