### PR TITLE
Add duplicate RP capabilities

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -94,11 +94,12 @@ node_grpc_compile()
 ################################
 
 load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
-     "graknlabs_graql", "graknlabs_common", "graknlabs_client_java")
+     "graknlabs_graql", "graknlabs_common", "graknlabs_client_java", "graknlabs_grabl_tracing")
 graknlabs_graql()
 graknlabs_common()
 graknlabs_client_java()
 graknlabs_console()
+graknlabs_grabl_tracing()
 
 load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl",
 graknlabs_grakn_core_maven_dependencies = "maven_dependencies")
@@ -115,6 +116,13 @@ antlr_dependencies()
 load("@graknlabs_graql//dependencies/maven:dependencies.bzl",
 graknlabs_graql_maven_dependencies = "maven_dependencies")
 graknlabs_graql_maven_dependencies()
+
+# Load Grabl Tracing dependencies for Grakn Core
+
+load("@graknlabs_grabl_tracing//dependencies/maven:dependencies.bzl",
+graknlabs_grabl_tracing_maven_dependencies="maven_dependencies")
+graknlabs_grabl_tracing_maven_dependencies()
+
 
 # Load Client Java dependencies for Grakn Core
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -94,20 +94,15 @@ node_grpc_compile()
 ################################
 
 load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
-     "graknlabs_graql", "graknlabs_common", "graknlabs_client_java", "graknlabs_benchmark")
+     "graknlabs_graql", "graknlabs_common", "graknlabs_client_java")
 graknlabs_graql()
 graknlabs_common()
 graknlabs_client_java()
 graknlabs_console()
-graknlabs_benchmark()
 
 load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl",
 graknlabs_grakn_core_maven_dependencies = "maven_dependencies")
 graknlabs_grakn_core_maven_dependencies()
-
-load("@graknlabs_benchmark//dependencies/maven:dependencies.bzl",
-graknlabs_benchmark_maven_dependencies = "maven_dependencies")
-graknlabs_benchmark_maven_dependencies()
 
 # Load Graql dependencies for Grakn Core
 

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,19 +28,19 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        tag = "1.6.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        tag = "1.7.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        tag = "1.0.4" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        tag = "1.0.5" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_console():
     git_repository(
         name = "graknlabs_console",
         remote = "https://github.com/graknlabs/console",
-        commit = "ba9128ab8b7495aae008b5bcf51c6618ac3d5d94" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_console
+        tag = "1.0.4" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_console
     )

--- a/src/service/Session/util/ResponseConverter.js
+++ b/src/service/Session/util/ResponseConverter.js
@@ -185,8 +185,8 @@ ResponseConverter.prototype.rolePlayersMap = async function (resp) {
     // Create map using string as key and set as value
     rolePlayers.forEach(rp => {
         const key = rp.role.id;
-        if (map.has(key)) map.set(key, map.get(key).add(rp.player));
-        else map.set(key, new Set([rp.player]));
+        if (map.has(key)) map.set(key, map.get(key).push(rp.player));
+        else map.set(key, [rp.player]);
     })
     const resultMap = new Map();
     // Convert map to use Role object as key

--- a/tests/service/session/transaction/Relation.test.js
+++ b/tests/service/session/transaction/Relation.test.js
@@ -53,7 +53,7 @@ describe("Relationsihp methods", () => {
         const map = await relation.rolePlayersMap();
         expect(map.size).toBe(2);
         Array.from(map.keys()).forEach(key => { expect(key.isRole()).toBeTruthy(); });
-        Array.from(map.values()).forEach(set => { expect(Array.from(set).length).toBe(1); });
+        Array.from(map.values()).forEach(array => { expect(array.length).toBe(1); });
         const rolePlayers = await (await relation.rolePlayers()).collect();
         expect(rolePlayers.length).toBe(2);
     });
@@ -70,9 +70,26 @@ describe("Relationsihp methods", () => {
         const map = await relation.rolePlayersMap();
         expect(map.size).toBe(1);
         Array.from(map.keys()).forEach(key => { expect(key.isRole()).toBeTruthy(); });
-        Array.from(map.values()).forEach(set => { expect(Array.from(set).length).toBe(2); });
+        Array.from(map.values()).forEach(array => { expect(array.length).toBe(2); });
         const rolePlayers = await (await relation.rolePlayers()).collect();
         expect(rolePlayers.length).toBe(2);
+    });
+
+    it("rolePlayersMap && rolePlayers with 1 duplicate role played", async () => {
+        const relationType = await tx.putRelationType('parenthood');
+        const relation = await relationType.create();
+        const parentRole = await tx.putRole('parent');
+        const personType = await tx.putEntityType('person');
+        const parent = await personType.create();
+        await relation.assign(parentRole, parent);
+        await relation.assign(parentRole, parent);
+        const map = await relation.rolePlayersMap();
+        expect(map.size).toBe(1);
+        Array.from(map.keys()).forEach(key => { expect(key.isRole()).toBeTruthy(); });
+        Array.from(map.values()).forEach(array => { expect(array.length).toBe(2); });
+        const rolePlayers = await (await relation.rolePlayers()).collect();
+        expect(rolePlayers.length).toBe(2);
+        expect((new Set(rolePlayers)).size == 1); // duplicate RP expected
     });
 
     it("rolePlayersMap && rolePlayers with 2 roles with the same player", async () => {
@@ -87,7 +104,7 @@ describe("Relationsihp methods", () => {
         const map = await relation.rolePlayersMap();
         expect(map.size).toBe(2);
         Array.from(map.keys()).forEach(key => { expect(key.isRole()).toBeTruthy(); });
-        Array.from(map.values()).forEach(set => { expect(Array.from(set).length).toBe(1); });
+        Array.from(map.values()).forEach(array => { expect(array.length).toBe(1); });
         const rolePlayers = await (await relation.rolePlayers()).collect();
         expect(rolePlayers.length).toBe(1);
         expect(rolePlayers[0].isThing()).toBeTruthy();


### PR DESCRIPTION
## What is the goal of this PR?
Add duplicate RP capabilities following the style of client-python's change at https://github.com/graknlabs/client-python/pull/85

## What are the changes implemented in this PR?
* Return a list instead of a set for role players
* update tests
* add a new test