### PR TITLE
Overhaul query options

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,15 +40,14 @@ bazel_common()
 bazel_toolchain()
 bazel_rules_python()
 
-load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip_import")
+load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
 pip_repositories()
 
-# Python dependencies for @graknlabs_build_tools and @graknlabs_bazel_distribution
-
-pip_import(
+pip3_import(
     name = "graknlabs_build_tools_ci_pip",
     requirements = "@graknlabs_build_tools//ci:requirements.txt",
 )
+
 load("@graknlabs_build_tools_ci_pip//:requirements.bzl",
 graknlabs_build_tools_ci_pip_install = "pip_install")
 graknlabs_build_tools_ci_pip_install()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,11 +22,10 @@ workspace(name = "graknlabs_client_nodejs")
 # Grakn Labs dependencies #
 ###########################
 
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_grakn_core", "graknlabs_build_tools", "graknlabs_protocol", "graknlabs_console")
+load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_grakn_core", "graknlabs_build_tools", "graknlabs_protocol")
 graknlabs_grakn_core()
 graknlabs_build_tools()
 graknlabs_protocol()
-graknlabs_console()
 
 load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
@@ -94,7 +93,7 @@ node_grpc_compile()
 ################################
 
 load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
-     "graknlabs_graql", "graknlabs_common", "graknlabs_client_java", "graknlabs_grabl_tracing")
+     "graknlabs_graql", "graknlabs_common", "graknlabs_client_java", "graknlabs_grabl_tracing", "graknlabs_console")
 graknlabs_graql()
 graknlabs_common()
 graknlabs_client_java()

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,12 +28,12 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/flyingsilverfin/grakn",
-        commit = "c7ff5c9bcd13ac7dee2c2237e658dd00e59fca17", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "ffff5a430dbccda54521bf1025d1cc23747f3ebf", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "6867388f3e7b74b53f2b9f4b33c936888b9e59b5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "6ce57b7df71f27aa68007f4bb819d5a8963aba45", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,7 +28,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/flyingsilverfin/grakn",
-        commit = "ffff5a430dbccda54521bf1025d1cc23747f3ebf", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "74d88885763ca8ff9b4b622245c4a09976f805c9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,7 +28,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/flyingsilverfin/grakn",
-        commit = "74d88885763ca8ff9b4b622245c4a09976f805c9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "eb820bb18d15b3d2ced763b09cd41211b93feb80", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -34,6 +34,6 @@ def graknlabs_grakn_core():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "6ce57b7df71f27aa68007f4bb819d5a8963aba45", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "8ba9a34eb208195fed6c98d4cfc11c8036a83c92", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,7 +28,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/flyingsilverfin/grakn",
-        commit = "eb820bb18d15b3d2ced763b09cd41211b93feb80", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "689ba5e2c215f4d775cb8c607924071515dd039c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -27,20 +27,13 @@ def graknlabs_build_tools():
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
-        remote = "https://github.com/graknlabs/grakn",
-        commit = "616326903dec49d4c56a5fe20fb84e33cd928cfb" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        remote = "https://github.com/flyingsilverfin/grakn",
+        commit = "eb0c2444e838ad9e973376bb2d7d61bcf88aaf96", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        commit = "c95a81b7a739a75f2164335e9566a2a4ce892bfa" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
-    )
-
-def graknlabs_console():
-    git_repository(
-        name = "graknlabs_console",
-        remote = "https://github.com/graknlabs/console",
-        commit = "14acafb9ea1297863f192d8f012c9cc0deaede06" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_console
+        remote = "https://github.com/flyingsilverfin/protocol",
+        commit = "6867388f3e7b74b53f2b9f4b33c936888b9e59b5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -21,14 +21,14 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "04f9678403cdbde889b8e25cc74d16bf1751fd81", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "715e4802ea375abda44e24b2bb092ee14de72e42", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/flyingsilverfin/grakn",
-        commit = "eb0c2444e838ad9e973376bb2d7d61bcf88aaf96", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "c7ff5c9bcd13ac7dee2c2237e658dd00e59fca17", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/src/service/Session/TransactionService.js
+++ b/src/service/Session/TransactionService.js
@@ -57,10 +57,10 @@ TransactionService.prototype.deleteConcept = function (id) {
 };
 
 // Schema concept
-TransactionService.prototype.getLabel = function (id) {
+TransactionService.prototype.getLabel = async function (id) {
     const txRequest = RequestBuilder.getLabel(id);
-    return this.communicator.send(txRequest)
-        .then(resp => this.respConverter.getLabel(resp));
+    const resp = await this.communicator.send(txRequest);
+    return this.respConverter.getLabel(resp);
 };
 TransactionService.prototype.setLabel = function (id, label) {
     const txRequest = RequestBuilder.setLabel(id, label);
@@ -76,10 +76,10 @@ TransactionService.prototype.sups = function (id) {
     return this.iteratorFactory.createIterator(iterRequest,
         (resp) => this.respConverter.sups(resp));
 };
-TransactionService.prototype.getSup = function (id) {
+TransactionService.prototype.getSup = async function (id) {
     const txRequest = RequestBuilder.getSup(id);
-    return this.communicator.send(txRequest)
-        .then(resp => this.respConverter.getSup(resp));
+    const resp = await this.communicator.send(txRequest);
+    return this.respConverter.getSup(resp);
 };
 TransactionService.prototype.setSup = function (id, superConcept) {
     const txRequest = RequestBuilder.setSup(id, superConcept);
@@ -87,15 +87,15 @@ TransactionService.prototype.setSup = function (id, superConcept) {
 };
 
 // Rule 
-TransactionService.prototype.getWhen = function (id) {
+TransactionService.prototype.getWhen = async function (id) {
     const txRequest = RequestBuilder.getWhen(id);
-    return this.communicator.send(txRequest)
-        .then(resp => this.respConverter.getWhen(resp));
+    const resp = await this.communicator.send(txRequest);
+    return this.respConverter.getWhen(resp);
 };
-TransactionService.prototype.getThen = function (id) {
+TransactionService.prototype.getThen = async function (id) {
     const txRequest = RequestBuilder.getThen(id);
-    return this.communicator.send(txRequest)
-        .then(resp => this.respConverter.getThen(resp));
+    const resp = await this.communicator.send(txRequest);
+    return this.respConverter.getThen(resp);
 };
 
 // Role
@@ -142,10 +142,10 @@ TransactionService.prototype.unsetKeyType = function (id, keyType) {
     const txRequest = RequestBuilder.unsetKeyType(id, keyType);
     return this.communicator.send(txRequest);
 };
-TransactionService.prototype.isAbstract = function (id) {
+TransactionService.prototype.isAbstract = async function (id) {
     const txRequest = RequestBuilder.isAbstract(id);
-    return this.communicator.send(txRequest)
-        .then(resp => this.respConverter.isAbstract(resp));
+    const resp = await this.communicator.send(txRequest);
+    return this.respConverter.isAbstract(resp);
 };
 TransactionService.prototype.setAbstract = function (id, bool) {
     const txRequest = RequestBuilder.setAbstract(id, bool);
@@ -166,17 +166,17 @@ TransactionService.prototype.unsetRolePlayedByType = function (id, role) {
 };
 
 // Entity type
-TransactionService.prototype.addEntity = function (id) {
+TransactionService.prototype.addEntity = async function (id) {
     const txRequest = RequestBuilder.addEntity(id);
-    return this.communicator.send(txRequest)
-        .then(resp => this.respConverter.addEntity(resp));
+    const resp = await this.communicator.send(txRequest);
+    return this.respConverter.addEntity(resp);
 };
 
 // Relation Type
-TransactionService.prototype.addRelation = function (id) {
+TransactionService.prototype.addRelation = async function (id) {
     const txRequest = RequestBuilder.addRelation(id);
-    return this.communicator.send(txRequest)
-        .then(resp => this.respConverter.addRelation(resp));
+    const resp = await this.communicator.send(txRequest);
+    return this.respConverter.addRelation(resp);
 };
 TransactionService.prototype.getRelatedRoles = function (id) {
     const iterRequest = RequestBuilder.getRelatedRoles(id);
@@ -209,15 +209,15 @@ TransactionService.prototype.getAttribute = async function (id, value) {
     return this.communicator.send(txRequest)
         .then(resp => this.respConverter.getAttribute(resp));
 };
-TransactionService.prototype.getValueTypeOfType = function (id) {
+TransactionService.prototype.getValueTypeOfType = async function (id) {
     const txRequest = RequestBuilder.getValueTypeOfType(id);
-    return this.communicator.send(txRequest)
-        .then(resp => this.respConverter.getValueTypeOfType(resp));
+    const resp = await this.communicator.send(txRequest);
+    return this.respConverter.getValueTypeOfType(resp);
 };
-TransactionService.prototype.getRegex = function (id) {
+TransactionService.prototype.getRegex = async function (id) {
     const txRequest = RequestBuilder.getRegex(id);
-    return this.communicator.send(txRequest)
-        .then(resp => this.respConverter.getRegex(resp));
+    const resp = await this.communicator.send(txRequest);
+    return this.respConverter.getRegex(resp);
 };
 TransactionService.prototype.setRegex = function (id, regex) {
     const txRequest = RequestBuilder.setRegex(id, regex);
@@ -225,15 +225,15 @@ TransactionService.prototype.setRegex = function (id, regex) {
 };
 
 //Thing
-TransactionService.prototype.isInferred = function (id) {
+TransactionService.prototype.isInferred = async function (id) {
     const txRequest = RequestBuilder.isInferred(id);
-    return this.communicator.send(txRequest)
-        .then(resp => this.respConverter.isInferred(resp));
+    const resp = await this.communicator.send(txRequest);
+    return this.respConverter.isInferred(resp);
 };
-TransactionService.prototype.getDirectType = function (id) {
+TransactionService.prototype.getDirectType = async function (id) {
     const txRequest = RequestBuilder.getDirectType(id);
-    return this.communicator.send(txRequest)
-        .then(response => this.respConverter.getDirectType(response));
+    const response = await this.communicator.send(txRequest);
+    return this.respConverter.getDirectType(response);
 };
 TransactionService.prototype.getRelationsByRoles = function (id, roles) {
     const iterRequest = RequestBuilder.getRelationsByRoles(id, roles);
@@ -285,10 +285,10 @@ TransactionService.prototype.unsetRolePlayer = function (id, role, thing) {
     return this.communicator.send(txRequest);
 };
 // Attribute
-TransactionService.prototype.getValue = function (id) {
+TransactionService.prototype.getValue = async function (id) {
     const txRequest = RequestBuilder.getValue(id);
-    return this.communicator.send(txRequest)
-        .then(response => this.respConverter.getValue(response));
+    const response = await this.communicator.send(txRequest);
+    return this.respConverter.getValue(response);
 };
 TransactionService.prototype.getOwners = function (id) {
     const iterRequest = RequestBuilder.getOwners(id);
@@ -298,46 +298,46 @@ TransactionService.prototype.getOwners = function (id) {
 
 // ======================= Grakn transaction methods ========================= //
 
-TransactionService.prototype.getConcept = function (conceptId) {
+TransactionService.prototype.getConcept = async function (conceptId) {
     const txRequest = RequestBuilder.getConcept(conceptId);
-    return this.communicator.send(txRequest)
-        .then((response) => this.respConverter.getConcept(response));
+    const response = await this.communicator.send(txRequest);
+    return this.respConverter.getConcept(response);
 }
 
-TransactionService.prototype.getSchemaConcept = function (label) {
+TransactionService.prototype.getSchemaConcept = async function (label) {
     const txRequest = RequestBuilder.getSchemaConcept(label);
-    return this.communicator.send(txRequest)
-        .then((response) => this.respConverter.getSchemaConcept(response));
+    const response = await this.communicator.send(txRequest);
+    return this.respConverter.getSchemaConcept(response);
 }
 
-TransactionService.prototype.putEntityType = function (label) {
+TransactionService.prototype.putEntityType = async function (label) {
     const txRequest = RequestBuilder.putEntityType(label);
-    return this.communicator.send(txRequest)
-        .then(response => this.respConverter.putEntityType(response));
+    const response = await this.communicator.send(txRequest);
+    return this.respConverter.putEntityType(response);
 }
 
-TransactionService.prototype.putRelationType = function (label) {
+TransactionService.prototype.putRelationType = async function (label) {
     const txRequest = RequestBuilder.putRelationType(label);
-    return this.communicator.send(txRequest)
-        .then(response => this.respConverter.putRelationType(response));
+    const response = await this.communicator.send(txRequest);
+    return this.respConverter.putRelationType(response);
 }
 
-TransactionService.prototype.putRole = function (label) {
+TransactionService.prototype.putRole = async function (label) {
     const txRequest = RequestBuilder.putRole(label);
-    return this.communicator.send(txRequest)
-        .then(response => this.respConverter.putRole(response));
+    const response = await this.communicator.send(txRequest);
+    return this.respConverter.putRole(response);
 }
 
-TransactionService.prototype.putRule = function (label, when, then) {
+TransactionService.prototype.putRule = async function (label, when, then) {
     const txRequest = RequestBuilder.putRule(label, when, then);
-    return this.communicator.send(txRequest)
-        .then(response => this.respConverter.putRule(response));
+    const response = await this.communicator.send(txRequest);
+    return this.respConverter.putRule(response);
 }
 
-TransactionService.prototype.putAttributeType = function (label, valueType) {
+TransactionService.prototype.putAttributeType = async function (label, valueType) {
     const txRequest = RequestBuilder.putAttributeType(label, valueType);
-    return this.communicator.send(txRequest)
-        .then(response => this.respConverter.putAttributeType(response));
+    const response = await this.communicator.send(txRequest);
+    return this.respConverter.putAttributeType(response);
 }
 
 TransactionService.prototype.getAttributesByValue = function (value, valueType) {
@@ -356,8 +356,8 @@ TransactionService.prototype.commit = function () {
     return this.communicator.send(txRequest);
 }
 
-TransactionService.prototype.query = function (query, options, batchSize = 50) {
-    const queryIter = RequestBuilder.startQueryIter(query, options, RequestBuilder.iterOptions(batchSize));
+TransactionService.prototype.query = function (query, options) {
+    const queryIter = RequestBuilder.startQueryIter(query, options, RequestBuilder.iterOptions(options.batchSize));
     return this.iteratorFactory.createQueryIterator(queryIter);
 };
 

--- a/src/service/Session/TransactionService.js
+++ b/src/service/Session/TransactionService.js
@@ -357,7 +357,7 @@ TransactionService.prototype.commit = function () {
 }
 
 TransactionService.prototype.query = function (query, options) {
-    const queryIter = RequestBuilder.startQueryIter(query, options, RequestBuilder.iterOptions(options.batchSize));
+    const queryIter = RequestBuilder.startQueryIter(query, options, RequestBuilder.iterOptions(options ? options.batchSize : undefined));
     return this.iteratorFactory.createQueryIterator(queryIter);
 };
 

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -548,10 +548,10 @@ const methods = {
     queryMessage.setQuery(query);
     if (options) {
       if ('infer' in options) {
-        optionsMessage.setInferFlag(options.infer);
+        optionsMessage.setInferflag(options.infer);
       }
       if ('explain' in options) {
-        optionsMessage.setExplainFlag(options.explain);
+        optionsMessage.setExplainflag(options.explain);
       }
     }
     queryMessage.setOptions(optionsMessage);

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -47,12 +47,16 @@ function RunConceptMethodIterRequest(conceptId, iterReq) {
   return iterMessage;
 }
 
-function IterOptions(batchSize = 50) {
+function IterOptions(batchSize) {
   const optionsMessage = new messages.Transaction.Iter.Req.Options();
-  if (batchSize > 0) {
-    optionsMessage.setNumber(batchSize);
-  } else {
-    optionsMessage.setAll(true);
+  if (batchSize !== undefined) {
+    if (batchSize == "all") {
+      optionsMessage.setAll(true);
+    } else if (typeof batchSize == "number" && batchSize > 0) {
+      optionsMessage.setNumber(batchSize);
+    } else {
+      throw new Error("Invalid batchSize parameter: " + batchSize);
+    }
   }
   return optionsMessage;
 }
@@ -542,12 +546,17 @@ const methods = {
     const iterMessage = new messages.Transaction.Iter.Req();
     iterMessage.setOptions(iterOptionsMessage);
     const queryMessage = new messages.Transaction.Query.Iter.Req();
+    const optionsMessage = new messages.Transaction.Query.Options();
     queryMessage.setQuery(query);
     if (options) {
       if ('infer' in options) {
-        queryMessage.setInfer(options.infer ? INFER_TRUE_MESSAGE : INFER_FALSE_MESSAGE);
+        optionsMessage.setInfer(options.infer);
+      }
+      if ('explain' in options) {
+        optionsMessage.setExplain(options.explain);
       }
     }
+    queryMessage.setOptions(optionsMessage);
     iterMessage.setQueryIterReq(queryMessage);
     return iterMessage;
   },

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -548,10 +548,10 @@ const methods = {
     queryMessage.setQuery(query);
     if (options) {
       if ('infer' in options) {
-        optionsMessage.setInfer(options.infer);
+        optionsMessage.setInferFlag(options.infer);
       }
       if ('explain' in options) {
-        optionsMessage.setExplain(options.explain);
+        optionsMessage.setExplainFlag(options.explain);
       }
     }
     queryMessage.setOptions(optionsMessage);

--- a/src/service/Session/util/RequestBuilder.js
+++ b/src/service/Session/util/RequestBuilder.js
@@ -21,8 +21,6 @@ const messages = require("../../../../grpc/nodejs/protocol/session/Session_pb");
 const answerMessages = require("../../../../grpc/nodejs/protocol/session/Answer_pb");
 const ConceptsBaseType = require("../concept/BaseTypeConstants").baseType;
 const ProtoValueType = require("../../../../grpc/nodejs/protocol/session/Concept_pb").AttributeType.VALUE_TYPE;
-const INFER_TRUE_MESSAGE = messages.Transaction.Query.INFER.TRUE;
-const INFER_FALSE_MESSAGE = messages.Transaction.Query.INFER.FALSE;
 
 // Helper functions
 

--- a/tests/service/session/transaction/CommitTx.test.js
+++ b/tests/service/session/transaction/CommitTx.test.js
@@ -66,7 +66,7 @@ describe('Integration test', () => {
         await newTx.close();
     });
 
-    it("explanation and default of infer is true", async () => {
+    it("explanation is true", async () => {
         const localSession = await graknClient.session("gene");
         let tx = await localSession.transaction().write();
         await tx.query(`
@@ -78,7 +78,7 @@ describe('Integration test', () => {
         await tx.commit();
 
         tx = await localSession.transaction().write();
-        const iterator = await tx.query("match $x isa cousins; get;");
+        const iterator = await tx.query("match $x isa cousins; get;", {explain: true});
         const answer = await iterator.next();
         expect(answer.map().size).toBe(1);
         expect((await answer.explanation()).getAnswers().length).toEqual(1);

--- a/tests/service/session/transaction/GraknTx.test.js
+++ b/tests/service/session/transaction/GraknTx.test.js
@@ -72,7 +72,7 @@ describe("Transaction methods", () => {
     await localTx.commit()
 
     localTx = await localSession.transaction().write();
-    const answers = await (await localTx.query("match (owner: $x, owned: $y) isa ownership; get;")).collect();
+    const answers = await (await localTx.query("match (owner: $x, owned: $y) isa ownership; get;", { explain: true })).collect();
 
     let hasExplanationCounter = 0;
     let noExplanationCounter = 0;

--- a/tests/service/session/transaction/Query.test.js
+++ b/tests/service/session/transaction/Query.test.js
@@ -73,4 +73,8 @@ describe("Query methods", () => {
     const results = await iterator.collect();
     expect(results.length).toEqual(128);
   })
+
+  it("accepts valid options", async () => {
+    await tx.query('insert $x isa person, has identifier "a";', { infer: false, explain: false, batchSize: "all" });
+  })
 });


### PR DESCRIPTION
## What is the goal of this PR?
We introduce modified `infer`, and new `batch_size`, and `explain` options for queries:

The default (undefined setting of the above options) value means that the server will automatically choose the default value for `infer`, `explain`, and `batch_size`. For reference, the server will default to `infer = true`, `explain = true`, and `batch_size = 50`.

** use `explain:true` if you want to retrieve explanations from your query ** This was introduced to ensure correct Explanations, without consuming too much Transaction memory when not required.

## What are the changes implemented in this PR?
* Introduce `explain` query option
* Include `batchSize` query option into the query options, instead of iteration options
* Throw exceptions if the types of parameters are passed in are incorrect.
* Tests for `explain` and `infer` flag