### PR TITLE
Add pulse to RPCSession

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4026,9 +4026,8 @@
       "dev": true
     },
     "graknlabs-grpc-protocol": {
-      "version": "2.0.0-alpha",
-      "resolved": "https://registry.npmjs.org/graknlabs-grpc-protocol/-/graknlabs-grpc-protocol-2.0.0-alpha.tgz",
-      "integrity": "sha512-cAYTD2S0jubZZQ/JIYe7n8XlhY22sa8k6FauT9lAq9Ih001LAcKW8gH6Xe5eiU4G5kDvkdhlkjoT8YHWsk9b/Q==",
+      "version": "https://repo.grakn.ai/repository/npm-snapshot/graknlabs-grpc-protocol/-/graknlabs-grpc-protocol-0.0.0-33b6a703781aeb7a86bdcb271409f6f74fb49d2d.tgz",
+      "integrity": "sha512-VMQptgfyUVH+BEvJI10zGAQYNmng5LEYs1xRI9Skr/G6Wog5pKPXmKCEnv/lWyxd17J63UeeWcEyvUjreY6ozQ==",
       "requires": {
         "@grpc/grpc-js": "1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.2.1",
     "google-protobuf": "3.12.4",
-    "graknlabs-grpc-protocol": "https://repo.grakn.ai/repository/npm-snapshot/graknlabs-grpc-protocol/-/graknlabs-grpc-protocol-0.0.0-33b6a703781aeb7a86bdcb271409f6f74fb49d2d.tgz"
+    "graknlabs-grpc-protocol": "https://repo.grakn.ai/repository/npm-snapshot/graknlabs-grpc-protocol/-/graknlabs-grpc-protocol-0.0.0-4a7ca2c7a0d3e13d8a9a3f7b25da0f6d01848230.tgz"
   },
   "devDependencies": {
     "@bazel/typescript": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.2.1",
     "google-protobuf": "3.12.4",
-    "graknlabs-grpc-protocol": "2.0.0-alpha"
+    "graknlabs-grpc-protocol": "https://repo.grakn.ai/repository/npm-snapshot/graknlabs-grpc-protocol/-/graknlabs-grpc-protocol-0.0.0-33b6a703781aeb7a86bdcb271409f6f74fb49d2d.tgz"
   },
   "devDependencies": {
     "@bazel/typescript": "2.3.1",

--- a/rpc/RPCSession.ts
+++ b/rpc/RPCSession.ts
@@ -33,6 +33,7 @@ export class RPCSession implements Grakn.Session {
     private readonly _type: Grakn.SessionType;
     private _sessionId: string;
     private _isOpen: boolean;
+    private _pulse: NodeJS.Timeout;
 
     constructor(grpcClient: GraknGrpc, database: string, type: Grakn.SessionType) {
         this._database = database;
@@ -53,6 +54,7 @@ export class RPCSession implements Grakn.Session {
             });
         });
         this._sessionId = res.getSessionId_asB64();
+        this._pulse = setTimeout(() => this.pulse(), 3000);
         return this;
     }
 
@@ -72,6 +74,7 @@ export class RPCSession implements Grakn.Session {
     async close(): Promise<void> {
         if (this._isOpen) {
             this._isOpen = false;
+            clearTimeout(this._pulse);
             const req = new SessionProto.Session.Close.Req().setSessionId(this._sessionId);
             await new Promise((resolve, reject) => {
                 this._grpcClient.session_close(req, (err) => {
@@ -84,6 +87,15 @@ export class RPCSession implements Grakn.Session {
 
     database(): string {
         return this._database;
+    }
+
+    pulse(): void {
+        if (!this._isOpen) return;
+        const pulse = new SessionProto.Session.Pulse.Req().setSessionId(this._sessionId);
+        this._grpcClient.session_pulse(pulse, (err, _res) => {
+            if (err) return;// Generally means the session has been closed, which is fine
+            else this._pulse = setTimeout(() => this.pulse(), 3000);
+        });
     }
 }
 

--- a/rpc/RPCSession.ts
+++ b/rpc/RPCSession.ts
@@ -54,7 +54,7 @@ export class RPCSession implements Grakn.Session {
             });
         });
         this._sessionId = res.getSessionId_asB64();
-        this._pulse = setTimeout(() => this.pulse(), 3000);
+        this._pulse = setTimeout(() => this.pulse(), 5000);
         return this;
     }
 
@@ -94,7 +94,7 @@ export class RPCSession implements Grakn.Session {
         const pulse = new SessionProto.Session.Pulse.Req().setSessionId(this._sessionId);
         this._grpcClient.session_pulse(pulse, (err, _res) => {
             if (err) return;// Generally means the session has been closed, which is fine
-            else this._pulse = setTimeout(() => this.pulse(), 3000);
+            else this._pulse = setTimeout(() => this.pulse(), 5000);
         });
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

1) To ensure Grakn remains usable after a client holding a schema session terminates abruptly: see https://github.com/graknlabs/client-java/issues/193 

## What are the changes implemented in this PR?

- Sessions now send a pulse to the server every 5 seconds while open
