### PR TITLE
Update protocol: repeated fields now pluralised

### DIFF
--- a/concept/thing/impl/AttributeImpl.ts
+++ b/concept/thing/impl/AttributeImpl.ts
@@ -67,7 +67,7 @@ export abstract class RemoteAttributeImpl<T extends ValueClass> extends RemoteTh
         const method = new ConceptProto.Thing.Req().setAttributeGetOwnersReq(
             new ConceptProto.Attribute.GetOwners.Req().setThingType(ConceptProtoBuilder.type(ownerType))
         );
-        return this.thingStream(method, res => res.getAttributeGetOwnersRes().getThingList()) as Stream<ThingImpl>;
+        return this.thingStream(method, res => res.getAttributeGetOwnersRes().getThingsList()) as Stream<ThingImpl>;
     }
 
     async getType(): Promise<AttributeTypeImpl> {

--- a/concept/thing/impl/RelationImpl.ts
+++ b/concept/thing/impl/RelationImpl.ts
@@ -67,7 +67,7 @@ export class RemoteRelationImpl extends RemoteThingImpl implements RemoteRelatio
             .setRelationGetPlayersByRoleTypeReq(new ConceptProto.Relation.GetPlayersByRoleType.Req())
             .setIid(this.getIID());
         const request = new TransactionProto.Transaction.Req().setThingReq(method);
-        const stream = (this.transaction as RPCTransaction).stream(request, res => res.getThingRes().getRelationGetPlayersByRoleTypeRes().getRoleTypeWithPlayerList())
+        const stream = (this.transaction as RPCTransaction).stream(request, res => res.getThingRes().getRelationGetPlayersByRoleTypeRes().getRoleTypesWithPlayersList())
         const rolePlayerMap = new Map<RoleTypeImpl, ThingImpl[]>();
         for await (const rolePlayer of stream) {
             const role = TypeImpl.of(rolePlayer.getRoleType()) as RoleTypeImpl;
@@ -84,7 +84,7 @@ export class RemoteRelationImpl extends RemoteThingImpl implements RemoteRelatio
     getPlayers(roleTypes: RoleType[] = []): Stream<ThingImpl> {
         const method = new ConceptProto.Thing.Req().setRelationGetPlayersReq(
             new ConceptProto.Relation.GetPlayers.Req().setRoleTypesList(roleTypes.map(roleType => ConceptProtoBuilder.type(roleType))));
-        return this.thingStream(method, res => res.getRelationGetPlayersRes().getThingList()) as Stream<ThingImpl>;
+        return this.thingStream(method, res => res.getRelationGetPlayersRes().getThingsList()) as Stream<ThingImpl>;
     }
 
     async addPlayer(roleType: RoleType, player: Thing): Promise<void> {

--- a/concept/thing/impl/ThingImpl.ts
+++ b/concept/thing/impl/ThingImpl.ts
@@ -120,20 +120,20 @@ export abstract class RemoteThingImpl implements RemoteThing {
         | Stream<DoubleAttributeImpl> | Stream<StringAttributeImpl> | Stream<DateTimeAttributeImpl> {
         if (typeof arg === "undefined") {
             const method = new ConceptProto.Thing.Req().setThingGetHasReq(new ConceptProto.Thing.GetHas.Req());
-            return this.thingStream(method, res => res.getThingGetHasRes().getAttributeList()) as Stream<AttributeImpl<ValueClass>>;
+            return this.thingStream(method, res => res.getThingGetHasRes().getAttributesList()) as Stream<AttributeImpl<ValueClass>>;
         }
         if (typeof arg === "boolean") {
             const method = new ConceptProto.Thing.Req().setThingGetHasReq(new ConceptProto.Thing.GetHas.Req().setKeysOnly(arg));
-            return this.thingStream(method, res => res.getThingGetHasRes().getAttributeList()) as Stream<AttributeImpl<ValueClass>>;
+            return this.thingStream(method, res => res.getThingGetHasRes().getAttributesList()) as Stream<AttributeImpl<ValueClass>>;
         }
         if (Array.isArray(arg)) {
             const method = new ConceptProto.Thing.Req()
                 .setThingGetHasReq(new ConceptProto.Thing.GetHas.Req().setAttributeTypesList(ConceptProtoBuilder.types(arg)));
-            return this.thingStream(method, res => res.getThingGetHasRes().getAttributeList()) as Stream<AttributeImpl<ValueClass>>;
+            return this.thingStream(method, res => res.getThingGetHasRes().getAttributesList()) as Stream<AttributeImpl<ValueClass>>;
         }
         const method = new ConceptProto.Thing.Req()
             .setThingGetHasReq(new ConceptProto.Thing.GetHas.Req().setAttributeTypesList([ConceptProtoBuilder.type(arg)]));
-        const stream = this.thingStream(method, res => res.getThingGetHasRes().getAttributeList());
+        const stream = this.thingStream(method, res => res.getThingGetHasRes().getAttributesList());
         if (arg instanceof BooleanAttributeTypeImpl) return stream as Stream<BooleanAttributeImpl>;
         if (arg instanceof LongAttributeTypeImpl) return stream as Stream<LongAttributeImpl>;
         if (arg instanceof DoubleAttributeTypeImpl) return stream as Stream<DoubleAttributeImpl>;
@@ -144,14 +144,14 @@ export abstract class RemoteThingImpl implements RemoteThing {
 
     getPlays(): Stream<RoleTypeImpl> {
         const method = new ConceptProto.Thing.Req().setThingGetPlaysReq(new ConceptProto.Thing.GetPlays.Req());
-        return this.typeStream(method, res => res.getThingGetPlaysRes().getRoleTypeList()) as Stream<RoleTypeImpl>;
+        return this.typeStream(method, res => res.getThingGetPlaysRes().getRoleTypesList()) as Stream<RoleTypeImpl>;
     }
 
     getRelations(): Stream<RelationImpl>;
     getRelations(roleTypes: RoleType[] = []): Stream<RelationImpl> {
         const method = new ConceptProto.Thing.Req().setThingGetRelationsReq(
             new ConceptProto.Thing.GetRelations.Req().setRoleTypesList(ConceptProtoBuilder.types(roleTypes)));
-        return this.thingStream(method, res => res.getThingGetRelationsRes().getRelationList()) as Stream<RelationImpl>;
+        return this.thingStream(method, res => res.getThingGetRelationsRes().getRelationsList()) as Stream<RelationImpl>;
     }
 
     async setHas(attribute: Attribute<AttributeType.ValueClass>): Promise<void> {

--- a/concept/type/impl/AttributeTypeImpl.ts
+++ b/concept/type/impl/AttributeTypeImpl.ts
@@ -109,7 +109,7 @@ export class RemoteAttributeTypeImpl extends RemoteThingTypeImpl implements Remo
     getOwners(onlyKey?: boolean): Stream<ThingTypeImpl> {
         const method = new ConceptProto.Type.Req()
             .setAttributeTypeGetOwnersReq(new ConceptProto.AttributeType.GetOwners.Req().setOnlyKey(onlyKey || false));
-        return this.typeStream(method, res => res.getAttributeTypeGetOwnersRes().getOwnerList()) as Stream<ThingTypeImpl>;
+        return this.typeStream(method, res => res.getAttributeTypeGetOwnersRes().getOwnersList()) as Stream<ThingTypeImpl>;
     }
 
     protected async putInternal(valueProto: ConceptProto.Attribute.Value): Promise<AttributeImpl<ValueClass>> {

--- a/concept/type/impl/RelationTypeImpl.ts
+++ b/concept/type/impl/RelationTypeImpl.ts
@@ -73,7 +73,7 @@ export class RemoteRelationTypeImpl extends RemoteThingTypeImpl implements Remot
 
         return this.typeStream(
             new ConceptProto.Type.Req().setRelationTypeGetRelatesReq(new ConceptProto.RelationType.GetRelates.Req()),
-            res => res.getRelationTypeGetRelatesRes().getRoleList()) as Stream<RoleTypeImpl>;
+            res => res.getRelationTypeGetRelatesRes().getRolesList()) as Stream<RoleTypeImpl>;
     }
 
     setRelates(roleLabel: string): Promise<void>;

--- a/concept/type/impl/RoleTypeImpl.ts
+++ b/concept/type/impl/RoleTypeImpl.ts
@@ -100,13 +100,13 @@ export class RemoteRoleTypeImpl extends RemoteThingTypeImpl implements RemoteRol
     getRelationTypes(): Stream<RelationTypeImpl> {
         return this.typeStream(
             new ConceptProto.Type.Req().setRoleTypeGetRelationTypesReq(new ConceptProto.RoleType.GetRelationTypes.Req()),
-            res => res.getRoleTypeGetRelationTypesRes().getRelationTypeList()) as Stream<RelationTypeImpl>;
+            res => res.getRoleTypeGetRelationTypesRes().getRelationTypesList()) as Stream<RelationTypeImpl>;
     }
 
     getPlayers(): Stream<ThingTypeImpl> {
         return this.typeStream(
             new ConceptProto.Type.Req().setRoleTypeGetPlayersReq(new ConceptProto.RoleType.GetPlayers.Req()),
-            res => res.getRoleTypeGetPlayersRes().getThingTypeList()) as Stream<ThingTypeImpl>;
+            res => res.getRoleTypeGetPlayersRes().getThingTypesList()) as Stream<ThingTypeImpl>;
     }
 
     protected typeStream(method: ConceptProto.Type.Req, typeGetter: (res: ConceptProto.Type.Res) => ConceptProto.Type[]): Stream<TypeImpl> {

--- a/concept/type/impl/ThingTypeImpl.ts
+++ b/concept/type/impl/ThingTypeImpl.ts
@@ -69,7 +69,7 @@ export class RemoteThingTypeImpl extends RemoteTypeImpl implements RemoteThingTy
 
     getInstances(): Stream<ThingImpl> {
         const request = new ConceptProto.Type.Req().setThingTypeGetInstancesReq(new ConceptProto.ThingType.GetInstances.Req());
-        return this.thingStream(request, res => res.getThingTypeGetInstancesRes().getThingList());
+        return this.thingStream(request, res => res.getThingTypeGetInstancesRes().getThingsList());
     }
 
     async setAbstract(): Promise<void> {
@@ -104,7 +104,7 @@ export class RemoteThingTypeImpl extends RemoteTypeImpl implements RemoteThingTy
 
     getPlays(): Stream<RoleTypeImpl> {
         const request = new ConceptProto.Type.Req().setThingTypeGetPlaysReq(new ConceptProto.ThingType.GetPlays.Req());
-        return this.typeStream(request, res => res.getThingTypeGetPlaysRes().getRoleList()) as Stream<RoleTypeImpl>;
+        return this.typeStream(request, res => res.getThingTypeGetPlaysRes().getRolesList()) as Stream<RoleTypeImpl>;
     }
 
     getOwns(): Stream<AttributeTypeImpl>;
@@ -117,7 +117,7 @@ export class RemoteThingTypeImpl extends RemoteTypeImpl implements RemoteThingTy
         // Here we take advantage of the fact that AttributeType.ValueType is a string enum
         if (typeof valueTypeOrKeysOnly === "string") getOwnsReq.setValueType(ConceptProtoBuilder.valueType(valueTypeOrKeysOnly));
         const request = new ConceptProto.Type.Req().setThingTypeGetOwnsReq(getOwnsReq);
-        return this.typeStream(request, res => res.getThingTypeGetOwnsRes().getAttributeTypeList()) as Stream<AttributeTypeImpl>;
+        return this.typeStream(request, res => res.getThingTypeGetOwnsRes().getAttributeTypesList()) as Stream<AttributeTypeImpl>;
     }
 
     async unsetPlays(role: RoleType): Promise<void> {

--- a/concept/type/impl/TypeImpl.ts
+++ b/concept/type/impl/TypeImpl.ts
@@ -114,12 +114,12 @@ export abstract class RemoteTypeImpl implements RemoteType {
 
     getSupertypes(): Stream<TypeImpl> {
         const method = new ConceptProto.Type.Req().setTypeGetSupertypesReq(new ConceptProto.Type.GetSupertypes.Req());
-        return this.typeStream(method, res => res.getTypeGetSupertypesRes().getTypeList());
+        return this.typeStream(method, res => res.getTypeGetSupertypesRes().getTypesList());
     }
 
     getSubtypes(): Stream<TypeImpl> {
         const method = new ConceptProto.Type.Req().setTypeGetSubtypesReq(new ConceptProto.Type.GetSubtypes.Req());
-        return this.typeStream(method, res => res.getTypeGetSubtypesRes().getTypeList());
+        return this.typeStream(method, res => res.getTypeGetSubtypesRes().getTypesList());
     }
 
     async delete(): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4026,8 +4026,8 @@
       "dev": true
     },
     "grakn-protocol": {
-      "version": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-c2e11c3b406a4736817bc50a57f6d3e3ede67a49.tgz",
-      "integrity": "sha512-Ufm0fm2/lvwo1RoQi7NC3+/Z8NtckSsmFycqsV2etIdLwPoM6poSN+Zly5b0Jv4UT9GlrUaC/8gJIYUjTHgPxg==",
+      "version": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-6bf8c601ecd57a2869cde56c17eec8784a9a2804.tgz",
+      "integrity": "sha512-vCPfG2QoevIG3iFpwOYJWS+FWx4xJlNAZlgJT4yualuhANRCodYx0Uy3xX0Cb8g5ksmJD0VB/PxwUkCn32Y0Rw==",
       "requires": {
         "@grpc/grpc-js": "1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.2.1",
     "google-protobuf": "3.12.4",
-    "grakn-protocol": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-c2e11c3b406a4736817bc50a57f6d3e3ede67a49.tgz"
+    "grakn-protocol": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-6bf8c601ecd57a2869cde56c17eec8784a9a2804.tgz"
   },
   "devDependencies": {
     "@bazel/typescript": "2.3.1",

--- a/query/QueryManager.ts
+++ b/query/QueryManager.ts
@@ -39,13 +39,13 @@ export class QueryManager {
     public match(query: string, options?: GraknOptions): Stream<ConceptMap> {
         const matchQuery = new Query.Req().setMatchReq(
             new Graql.Match.Req().setQuery(query));
-        return this.iterateQuery(matchQuery, options ? options : new GraknOptions(), (res: Transaction.Res) => res.getQueryRes().getMatchRes().getAnswerList().map(ConceptMap.of));
+        return this.iterateQuery(matchQuery, options ? options : new GraknOptions(), (res: Transaction.Res) => res.getQueryRes().getMatchRes().getAnswersList().map(ConceptMap.of));
     }
 
     public insert(query: string, options?: GraknOptions): Stream<ConceptMap> {
         const insertQuery = new Query.Req().setInsertReq(
             new Graql.Insert.Req().setQuery(query));
-        return this.iterateQuery(insertQuery, options ? options : new GraknOptions(), (res: Transaction.Res) => res.getQueryRes().getInsertRes().getAnswerList().map(ConceptMap.of));
+        return this.iterateQuery(insertQuery, options ? options : new GraknOptions(), (res: Transaction.Res) => res.getQueryRes().getInsertRes().getAnswersList().map(ConceptMap.of));
     }
 
     public delete(query: string, options?: GraknOptions): Promise<void> {


### PR DESCRIPTION
## What is the goal of this PR?

We updated our repeated field names in our protocol, ensuring they are consistently pluralised in line with the Protocol Buffers style guide.

## What are the changes implemented in this PR?

- Make all repeated protocol fields pluralised