### PR TITLE
Fix Attribute.GetOwners with no parameter

### DIFF
--- a/concept/thing/Attribute.ts
+++ b/concept/thing/Attribute.ts
@@ -22,7 +22,7 @@ import {
     RemoteThing,
     AttributeType,
     Grakn,
-    Merge,
+    Merge, Stream, ThingType,
 } from "../../dependencies_internal";
 import ValueClass = AttributeType.ValueClass;
 import Transaction = Grakn.Transaction;
@@ -34,7 +34,10 @@ export interface Attribute<T extends ValueClass> extends Thing {
 }
 
 export interface RemoteAttribute<T extends ValueClass> extends Merge<RemoteThing, Attribute<T>> {
+    getOwners(): Stream<Thing>;
+    getOwners(ownerType: ThingType): Stream<Thing>;
     getType(): Promise<AttributeType>;
+
     asRemote(transaction: Transaction): RemoteAttribute<T>;
 }
 

--- a/concept/thing/impl/AttributeImpl.ts
+++ b/concept/thing/impl/AttributeImpl.ts
@@ -63,10 +63,11 @@ export abstract class RemoteAttributeImpl<T extends ValueClass> extends RemoteTh
         super(transaction, iid);
     }
 
-    getOwners(ownerType: ThingType): Stream<ThingImpl> {
-        const method = new ConceptProto.Thing.Req().setAttributeGetOwnersReq(
-            new ConceptProto.Attribute.GetOwners.Req().setThingType(ConceptProtoBuilder.type(ownerType))
-        );
+    getOwners(): Stream<ThingImpl>;
+    getOwners(ownerType?: ThingType): Stream<ThingImpl> {
+        const getOwnersReq = new ConceptProto.Attribute.GetOwners.Req();
+        if (ownerType) getOwnersReq.setThingType(ConceptProtoBuilder.type(ownerType));
+        const method = new ConceptProto.Thing.Req().setAttributeGetOwnersReq(getOwnersReq);
         return this.thingStream(method, res => res.getAttributeGetOwnersRes().getThingsList()) as Stream<ThingImpl>;
     }
 
@@ -166,7 +167,7 @@ export class RemoteLongAttributeImpl extends RemoteAttributeImpl<number> impleme
     }
 }
 
-export class DoubleAttributeImpl extends AttributeImpl<number> implements Attribute<number> {
+export class DoubleAttributeImpl extends AttributeImpl<number> implements DoubleAttribute {
     private readonly _value: number;
 
     constructor(iid: string, value: number) {
@@ -210,7 +211,7 @@ export class RemoteDoubleAttributeImpl extends RemoteAttributeImpl<number> imple
     }
 }
 
-export class StringAttributeImpl extends AttributeImpl<string> implements Attribute<string> {
+export class StringAttributeImpl extends AttributeImpl<string> implements StringAttribute {
     private readonly _value: string;
 
     constructor(iid: string, value: string) {

--- a/concept/thing/impl/AttributeImpl.ts
+++ b/concept/thing/impl/AttributeImpl.ts
@@ -63,7 +63,6 @@ export abstract class RemoteAttributeImpl<T extends ValueClass> extends RemoteTh
         super(transaction, iid);
     }
 
-    getOwners(): Stream<ThingImpl>;
     getOwners(ownerType?: ThingType): Stream<ThingImpl> {
         const getOwnersReq = new ConceptProto.Attribute.GetOwners.Req();
         if (ownerType) getOwnersReq.setThingType(ConceptProtoBuilder.type(ownerType));

--- a/concept/thing/impl/RelationImpl.ts
+++ b/concept/thing/impl/RelationImpl.ts
@@ -80,7 +80,6 @@ export class RemoteRelationImpl extends RemoteThingImpl implements RemoteRelatio
         return rolePlayerMap;
     }
 
-    getPlayers(): Stream<ThingImpl>;
     getPlayers(roleTypes: RoleType[] = []): Stream<ThingImpl> {
         const method = new ConceptProto.Thing.Req().setRelationGetPlayersReq(
             new ConceptProto.Relation.GetPlayers.Req().setRoleTypesList(roleTypes.map(roleType => ConceptProtoBuilder.type(roleType))));

--- a/concept/thing/impl/ThingImpl.ts
+++ b/concept/thing/impl/ThingImpl.ts
@@ -147,7 +147,6 @@ export abstract class RemoteThingImpl implements RemoteThing {
         return this.typeStream(method, res => res.getThingGetPlaysRes().getRoleTypesList()) as Stream<RoleTypeImpl>;
     }
 
-    getRelations(): Stream<RelationImpl>;
     getRelations(roleTypes: RoleType[] = []): Stream<RelationImpl> {
         const method = new ConceptProto.Thing.Req().setThingGetRelationsReq(
             new ConceptProto.Thing.GetRelations.Req().setRoleTypesList(ConceptProtoBuilder.types(roleTypes)));

--- a/concept/type/impl/AttributeTypeImpl.ts
+++ b/concept/type/impl/AttributeTypeImpl.ts
@@ -105,7 +105,6 @@ export class RemoteAttributeTypeImpl extends RemoteThingTypeImpl implements Remo
         return super.getInstances() as Stream<AttributeImpl<ValueClass>>;
     }
 
-    getOwners(): Stream<ThingTypeImpl>;
     getOwners(onlyKey?: boolean): Stream<ThingTypeImpl> {
         const method = new ConceptProto.Type.Req()
             .setAttributeTypeGetOwnersReq(new ConceptProto.AttributeType.GetOwners.Req().setOnlyKey(onlyKey || false));

--- a/concept/type/impl/RelationTypeImpl.ts
+++ b/concept/type/impl/RelationTypeImpl.ts
@@ -76,8 +76,6 @@ export class RemoteRelationTypeImpl extends RemoteThingTypeImpl implements Remot
             res => res.getRelationTypeGetRelatesRes().getRolesList()) as Stream<RoleTypeImpl>;
     }
 
-    setRelates(roleLabel: string): Promise<void>;
-    setRelates(roleLabel: string, overriddenLabel: string): Promise<void>;
     async setRelates(roleLabel: string, overriddenLabel?: string): Promise<void> {
         const setRelatesReq = new ConceptProto.RelationType.SetRelates.Req().setLabel(roleLabel);
         if (overriddenLabel != null) setRelatesReq.setOverriddenLabel(overriddenLabel);

--- a/concept/type/impl/ThingTypeImpl.ts
+++ b/concept/type/impl/ThingTypeImpl.ts
@@ -80,8 +80,6 @@ export class RemoteThingTypeImpl extends RemoteTypeImpl implements RemoteThingTy
         await this.execute(new ConceptProto.Type.Req().setThingTypeUnsetAbstractReq(new ConceptProto.ThingType.UnsetAbstract.Req()));
     }
 
-    async setPlays(role: RoleType): Promise<void>;
-    async setPlays(role: RoleType, overriddenType: RoleType): Promise<void>;
     async setPlays(role: RoleType, overriddenType?: RoleType): Promise<void> {
         const setPlaysReq = new ConceptProto.ThingType.SetPlays.Req().setRole(ConceptProtoBuilder.type(role));
         if (overriddenType) setPlaysReq.setOverriddenRole(ConceptProtoBuilder.type(overriddenType));


### PR DESCRIPTION
## What is the goal of this PR?

We ensure GetOwners is correctly declared in the Attribute interface and properly implemented in AttributeImpl. Previously it would throw an exception if called with no parameter, but this is legal in client-java.

## What are the changes implemented in this PR?

- Fix Attribute.GetOwners with no parameter throwing an error
