### PR TITLE
Remove leftover TODOs related to hex string conversions

### DIFF
--- a/concept/thing/impl/AttributeImpl.ts
+++ b/concept/thing/impl/AttributeImpl.ts
@@ -89,7 +89,6 @@ export class BooleanAttributeImpl extends AttributeImpl<boolean> implements Bool
     }
 
     static of(protoThing: ConceptProto.Thing): BooleanAttributeImpl {
-        // TODO
         return new BooleanAttributeImpl(Bytes.bytesToHexString(protoThing.getIid_asU8()), protoThing.getValue().getBoolean());
     }
 
@@ -133,7 +132,6 @@ export class LongAttributeImpl extends AttributeImpl<number> implements LongAttr
     }
 
     static of(protoThing: ConceptProto.Thing): LongAttributeImpl {
-        // TODO
         return new LongAttributeImpl(Bytes.bytesToHexString(protoThing.getIid_asU8()), protoThing.getValue().getLong());
     }
 
@@ -177,7 +175,6 @@ export class DoubleAttributeImpl extends AttributeImpl<number> implements Double
     }
 
     static of(protoThing: ConceptProto.Thing): DoubleAttributeImpl {
-        // TODO
         return new DoubleAttributeImpl(Bytes.bytesToHexString(protoThing.getIid_asU8()), protoThing.getValue().getDouble());
     }
 
@@ -222,7 +219,6 @@ export class StringAttributeImpl extends AttributeImpl<string> implements String
     }
 
     static of(protoThing: ConceptProto.Thing): StringAttributeImpl {
-        // TODO
         return new StringAttributeImpl(Bytes.bytesToHexString(protoThing.getIid_asU8()), protoThing.getValue().getString());
     }
 
@@ -266,7 +262,6 @@ export class DateTimeAttributeImpl extends AttributeImpl<Date> implements DateTi
     }
 
     static of(protoThing: ConceptProto.Thing): DateTimeAttributeImpl {
-        // TODO
         return new DateTimeAttributeImpl(Bytes.bytesToHexString(protoThing.getIid_asU8()), new Date(protoThing.getValue().getDateTime()));
     }
 

--- a/concept/thing/impl/EntityImpl.ts
+++ b/concept/thing/impl/EntityImpl.ts
@@ -34,7 +34,6 @@ export class EntityImpl extends ThingImpl implements Entity {
     }
 
     static of(protoThing: ConceptProto.Thing): EntityImpl {
-        // TODO: we should probably implement Bytes.bytesToHexString from @graknlabs_common
         return new EntityImpl(Bytes.bytesToHexString(protoThing.getIid_asU8()));
     }
 

--- a/concept/type/impl/AttributeTypeImpl.ts
+++ b/concept/type/impl/AttributeTypeImpl.ts
@@ -134,7 +134,6 @@ export class BooleanAttributeTypeImpl extends AttributeTypeImpl implements Boole
     }
 
     static of(typeProto: ConceptProto.Type): BooleanAttributeTypeImpl {
-        // TODO
         return new BooleanAttributeTypeImpl(typeProto.getLabel(), typeProto.getRoot());
     }
 
@@ -383,7 +382,6 @@ export class DateTimeAttributeTypeImpl extends AttributeTypeImpl implements Date
     }
 
     static of(typeProto: ConceptProto.Type): DateTimeAttributeTypeImpl {
-        // TODO
         return new DateTimeAttributeTypeImpl(typeProto.getLabel(), typeProto.getRoot());
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We have refactored the code to remove leftover TODOs, all related to byte - hex string conversions.