### PR TITLE
Protocol Synchronisation

### DIFF
--- a/concept/ConceptManager.ts
+++ b/concept/ConceptManager.ts
@@ -109,7 +109,7 @@ export class ConceptManager {
             return null;
     }
 
-    private async getThingType(label: string): Promise<ThingType> {
+    async getThingType(label: string): Promise<ThingType> {
         const req = new ConceptProto.ConceptManager.Req()
             .setGetThingTypeReq(new ConceptProto.ConceptManager.GetThingType.Req().setLabel(label));
         const res = await this.execute(req);

--- a/concept/ConceptManager.ts
+++ b/concept/ConceptManager.ts
@@ -28,7 +28,7 @@ import {
     RPCTransaction,
     RelationTypeImpl,
     AttributeTypeImpl,
-    Thing, ThingImpl, TypeImpl, Bytes,
+    Thing, ThingImpl, TypeImpl, Bytes, ThingTypeImpl,
 } from "../dependencies_internal";
 import ConceptProto from "grakn-protocol/protobuf/concept_pb";
 import TransactionProto from "grakn-protocol/protobuf/transaction_pb";
@@ -41,19 +41,19 @@ export class ConceptManager {
     }
 
     async getRootThingType(): Promise<ThingType> {
-        return await this.getType("thing") as ThingType;
+        return await this.getThingType("thing") as ThingType;
     }
 
     async getRootEntityType(): Promise<EntityType> {
-        return await this.getType("entity") as EntityType;
+        return await this.getThingType("entity") as EntityType;
     }
 
     async getRootRelationType(): Promise<RelationType> {
-        return await this.getType("relation") as RelationType;
+        return await this.getThingType("relation") as RelationType;
     }
 
     async getRootAttributeType(): Promise<AttributeType> {
-        return await this.getType("attribute") as AttributeType;
+        return await this.getThingType("attribute") as AttributeType;
     }
 
     async putEntityType(label: string): Promise<EntityType> {
@@ -64,7 +64,7 @@ export class ConceptManager {
     }
 
     async getEntityType(label: string): Promise<EntityType> {
-        const type = await this.getType(label);
+        const type = await this.getThingType(label);
         if (type instanceof EntityTypeImpl) return type as EntityType;
         else return null;
     }
@@ -77,7 +77,7 @@ export class ConceptManager {
     }
 
     async getRelationType(label: string): Promise<RelationType> {
-        const type = await this.getType(label);
+        const type = await this.getThingType(label);
         if (type instanceof RelationTypeImpl) return type as RelationType;
         else return null;
     }
@@ -92,7 +92,7 @@ export class ConceptManager {
     }
 
     async getAttributeType(label: string): Promise<AttributeType> {
-        const type = await this.getType(label);
+        const type = await this.getThingType(label);
         if (type instanceof AttributeTypeImpl) return type as AttributeType;
         else return null;
     }
@@ -107,12 +107,12 @@ export class ConceptManager {
             return null;
     }
 
-    async getType(label: string): Promise<Type> {
+    private async getThingType(label: string): Promise<ThingType> {
         const req = new ConceptProto.ConceptManager.Req()
             .setGetTypeReq(new ConceptProto.ConceptManager.GetType.Req().setLabel(label));
         const res = await this.execute(req);
         if (res.getGetTypeRes().getResCase() === ConceptProto.ConceptManager.GetType.Res.ResCase.TYPE)
-            return TypeImpl.of(res.getGetTypeRes().getType());
+            return ThingTypeImpl.of(res.getGetTypeRes().getType());
         else
             return null;
     }

--- a/concept/ConceptManager.ts
+++ b/concept/ConceptManager.ts
@@ -109,10 +109,10 @@ export class ConceptManager {
 
     private async getThingType(label: string): Promise<ThingType> {
         const req = new ConceptProto.ConceptManager.Req()
-            .setGetTypeReq(new ConceptProto.ConceptManager.GetType.Req().setLabel(label));
+            .setGetThingTypeReq(new ConceptProto.ConceptManager.GetThingType.Req().setLabel(label));
         const res = await this.execute(req);
-        if (res.getGetTypeRes().getResCase() === ConceptProto.ConceptManager.GetType.Res.ResCase.TYPE)
-            return ThingTypeImpl.of(res.getGetTypeRes().getThingType());
+        if (res.getGetThingTypeRes().getResCase() === ConceptProto.ConceptManager.GetThingType.Res.ResCase.THING_TYPE)
+            return ThingTypeImpl.of(res.getGetThingTypeRes().getThingType());
         else
             return null;
     }

--- a/concept/ConceptManager.ts
+++ b/concept/ConceptManager.ts
@@ -112,7 +112,7 @@ export class ConceptManager {
             .setGetTypeReq(new ConceptProto.ConceptManager.GetType.Req().setLabel(label));
         const res = await this.execute(req);
         if (res.getGetTypeRes().getResCase() === ConceptProto.ConceptManager.GetType.Res.ResCase.TYPE)
-            return ThingTypeImpl.of(res.getGetTypeRes().getType());
+            return ThingTypeImpl.of(res.getGetTypeRes().getThingType());
         else
             return null;
     }

--- a/concept/ConceptManager.ts
+++ b/concept/ConceptManager.ts
@@ -24,11 +24,13 @@ import {
     RelationType,
     AttributeType,
     EntityTypeImpl,
-    Type,
     RPCTransaction,
     RelationTypeImpl,
     AttributeTypeImpl,
-    Thing, ThingImpl, TypeImpl, Bytes, ThingTypeImpl,
+    Thing,
+    ThingImpl,
+    Bytes,
+    ThingTypeImpl,
 } from "../dependencies_internal";
 import ConceptProto from "grakn-protocol/protobuf/concept_pb";
 import TransactionProto from "grakn-protocol/protobuf/transaction_pb";

--- a/concept/ConceptManager.ts
+++ b/concept/ConceptManager.ts
@@ -43,7 +43,7 @@ export class ConceptManager {
     }
 
     async getRootThingType(): Promise<ThingType> {
-        return await this.getThingType("thing") as ThingType;
+        return await this.getThingType("thing");
     }
 
     async getRootEntityType(): Promise<EntityType> {

--- a/concept/type/AttributeType.ts
+++ b/concept/type/AttributeType.ts
@@ -41,6 +41,12 @@ export interface AttributeType extends ThingType {
     getValueType(): ValueType;
     isKeyable(): boolean;
 
+    isBoolean(): boolean;
+    isLong(): boolean;
+    isDouble(): boolean;
+    isString(): boolean;
+    isDateTime(): boolean;
+
     asRemote(transaction: Transaction): RemoteAttributeType;
 }
 

--- a/concept/type/AttributeType.ts
+++ b/concept/type/AttributeType.ts
@@ -46,7 +46,6 @@ export interface AttributeType extends ThingType {
 
 export interface RemoteAttributeType extends Merge<RemoteThingType, AttributeType> {
     setSupertype(type: AttributeType): Promise<void>;
-    getSupertype(): Promise<AttributeType>;
     getSubtypes(): Stream<AttributeType>;
     getInstances(): Stream<Attribute<ValueClass>>;
     getOwners(): Stream<ThingType>;
@@ -63,7 +62,6 @@ export interface RemoteBooleanAttributeType extends Merge<RemoteAttributeType, B
     asRemote(transaction: Transaction): RemoteBooleanAttributeType;
 
     setSupertype(type: BooleanAttributeType): Promise<void>;
-    getSupertype(): Promise<BooleanAttributeType>;
     getSubtypes(): Stream<BooleanAttributeType>;
     getInstances(): Stream<BooleanAttribute>;
 
@@ -79,7 +77,6 @@ export interface RemoteLongAttributeType extends Merge<RemoteAttributeType, Long
     asRemote(transaction: Transaction): RemoteLongAttributeType;
 
     setSupertype(type: LongAttributeType): Promise<void>;
-    getSupertype(): Promise<LongAttributeType>;
     getSubtypes(): Stream<LongAttributeType>;
     getInstances(): Stream<LongAttribute>;
 
@@ -95,7 +92,6 @@ export interface RemoteDoubleAttributeType extends Merge<RemoteAttributeType, Do
     asRemote(transaction: Transaction): RemoteDoubleAttributeType;
 
     setSupertype(type: DoubleAttributeType): Promise<void>;
-    getSupertype(): Promise<DoubleAttributeType>;
     getSubtypes(): Stream<DoubleAttributeType>;
     getInstances(): Stream<DoubleAttribute>;
 
@@ -111,7 +107,6 @@ export interface RemoteStringAttributeType extends Merge<RemoteAttributeType, St
     asRemote(transaction: Transaction): RemoteStringAttributeType;
 
     setSupertype(type: StringAttributeType): Promise<void>;
-    getSupertype(): Promise<StringAttributeType>;
     getSubtypes(): Stream<StringAttributeType>;
     getInstances(): Stream<StringAttribute>;
 
@@ -127,7 +122,6 @@ export interface RemoteDateTimeAttributeType extends Merge<RemoteAttributeType, 
     asRemote(transaction: Transaction): RemoteDateTimeAttributeType;
 
     setSupertype(type: DateTimeAttributeType): Promise<void>;
-    getSupertype(): Promise<DateTimeAttributeType>;
     getSubtypes(): Stream<DateTimeAttributeType>;
     getInstances(): Stream<DateTimeAttribute>;
 

--- a/concept/type/AttributeType.ts
+++ b/concept/type/AttributeType.ts
@@ -47,7 +47,6 @@ export interface AttributeType extends ThingType {
 export interface RemoteAttributeType extends Merge<RemoteThingType, AttributeType> {
     setSupertype(type: AttributeType): Promise<void>;
     getSupertype(): Promise<AttributeType>;
-    getSupertypes(): Stream<AttributeType>;
     getSubtypes(): Stream<AttributeType>;
     getInstances(): Stream<Attribute<ValueClass>>;
     getOwners(): Stream<ThingType>;
@@ -65,7 +64,6 @@ export interface RemoteBooleanAttributeType extends Merge<RemoteAttributeType, B
 
     setSupertype(type: BooleanAttributeType): Promise<void>;
     getSupertype(): Promise<BooleanAttributeType>;
-    getSupertypes(): Stream<BooleanAttributeType>;
     getSubtypes(): Stream<BooleanAttributeType>;
     getInstances(): Stream<BooleanAttribute>;
 
@@ -82,7 +80,6 @@ export interface RemoteLongAttributeType extends Merge<RemoteAttributeType, Long
 
     setSupertype(type: LongAttributeType): Promise<void>;
     getSupertype(): Promise<LongAttributeType>;
-    getSupertypes(): Stream<LongAttributeType>;
     getSubtypes(): Stream<LongAttributeType>;
     getInstances(): Stream<LongAttribute>;
 
@@ -99,7 +96,6 @@ export interface RemoteDoubleAttributeType extends Merge<RemoteAttributeType, Do
 
     setSupertype(type: DoubleAttributeType): Promise<void>;
     getSupertype(): Promise<DoubleAttributeType>;
-    getSupertypes(): Stream<DoubleAttributeType>;
     getSubtypes(): Stream<DoubleAttributeType>;
     getInstances(): Stream<DoubleAttribute>;
 
@@ -116,7 +112,6 @@ export interface RemoteStringAttributeType extends Merge<RemoteAttributeType, St
 
     setSupertype(type: StringAttributeType): Promise<void>;
     getSupertype(): Promise<StringAttributeType>;
-    getSupertypes(): Stream<StringAttributeType>;
     getSubtypes(): Stream<StringAttributeType>;
     getInstances(): Stream<StringAttribute>;
 
@@ -133,7 +128,6 @@ export interface RemoteDateTimeAttributeType extends Merge<RemoteAttributeType, 
 
     setSupertype(type: DateTimeAttributeType): Promise<void>;
     getSupertype(): Promise<DateTimeAttributeType>;
-    getSupertypes(): Stream<DateTimeAttributeType>;
     getSubtypes(): Stream<DateTimeAttributeType>;
     getInstances(): Stream<DateTimeAttribute>;
 

--- a/concept/type/EntityType.ts
+++ b/concept/type/EntityType.ts
@@ -35,7 +35,6 @@ export interface RemoteEntityType extends Merge<RemoteThingType, EntityType> {
     create(): Promise<Entity>;
 
     setSupertype(superEntityType: EntityType): Promise<void>;
-    getSupertype(): Promise<EntityType>;
     getSubtypes(): Stream<EntityType>;
     getInstances(): Stream<Entity>;
 

--- a/concept/type/EntityType.ts
+++ b/concept/type/EntityType.ts
@@ -36,7 +36,6 @@ export interface RemoteEntityType extends Merge<RemoteThingType, EntityType> {
 
     setSupertype(superEntityType: EntityType): Promise<void>;
     getSupertype(): Promise<EntityType>;
-    getSupertypes(): Stream<EntityType>;
     getSubtypes(): Stream<EntityType>;
     getInstances(): Stream<Entity>;
 

--- a/concept/type/RelationType.ts
+++ b/concept/type/RelationType.ts
@@ -42,7 +42,6 @@ export interface RemoteRelationType extends Merge<RemoteThingType, RelationType>
     unsetRelates(roleLabel: string): Promise<void>;
 
     setSupertype(relationType: RelationType): Promise<void>;
-    getSupertype(): Promise<RelationType>;
     getSubtypes(): Stream<RelationType>;
     getInstances(): Stream<Relation>;
 

--- a/concept/type/RelationType.ts
+++ b/concept/type/RelationType.ts
@@ -43,7 +43,6 @@ export interface RemoteRelationType extends Merge<RemoteThingType, RelationType>
 
     setSupertype(relationType: RelationType): Promise<void>;
     getSupertype(): Promise<RelationType>;
-    getSupertypes(): Stream<RelationType>;
     getSubtypes(): Stream<RelationType>;
     getInstances(): Stream<Relation>;
 

--- a/concept/type/Type.ts
+++ b/concept/type/Type.ts
@@ -30,6 +30,11 @@ export interface Type extends Concept {
     getLabel(): string;
     isRoot(): boolean;
 
+    isThingType(): boolean;
+    isAttributeType(): boolean;
+    isEntityType(): boolean;
+    isRelationType(): boolean;
+
     asRemote(transaction: Transaction): RemoteType;
 }
 

--- a/concept/type/impl/AttributeTypeImpl.ts
+++ b/concept/type/impl/AttributeTypeImpl.ts
@@ -69,12 +69,60 @@ export class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
     asRemote(transaction: Transaction): RemoteAttributeTypeImpl {
         return new RemoteAttributeTypeImpl(transaction, this.getLabel(), this.isRoot())
     }
+
+    isAttributeType(): boolean {
+        return true;
+    }
+
+    isBoolean(): boolean {
+        return false;
+    }
+
+    isString(): boolean {
+        return false;
+    }
+
+    isDouble(): boolean {
+        return false;
+    }
+
+    isLong(): boolean {
+        return false;
+    }
+
+    isDateTime(): boolean {
+        return false;
+    }
 }
 
 export class RemoteAttributeTypeImpl extends RemoteThingTypeImpl implements RemoteAttributeType {
 
     constructor(transaction: Transaction, label: string, isRoot: boolean) {
         super(transaction, label, isRoot);
+    }
+
+    isAttributeType(): boolean {
+        return true;
+    }
+
+    isBoolean(): boolean {
+        return false;
+    }
+
+    isString(): boolean {
+        return false;
+    }
+
+    isDouble(): boolean {
+        return false;
+    }
+
+    isLong(): boolean {
+        return false;
+    }
+
+    isDateTime(): boolean {
+        return false;
     }
 
     getValueType(): ValueType {
@@ -125,6 +173,10 @@ export class BooleanAttributeTypeImpl extends AttributeTypeImpl implements Boole
         super(label, isRoot);
     }
 
+    isBoolean(): boolean {
+        return true;
+    }
+
     static of(typeProto: ConceptProto.Type): BooleanAttributeTypeImpl {
         return new BooleanAttributeTypeImpl(typeProto.getLabel(), typeProto.getRoot());
     }
@@ -142,6 +194,10 @@ export class RemoteBooleanAttributeTypeImpl extends RemoteAttributeTypeImpl impl
 
     constructor(transaction: Transaction, label: string, isRoot: boolean) {
         super(transaction, label, isRoot);
+    }
+
+    isBoolean(): boolean {
+        return true;
     }
 
     getValueType(): ValueType {
@@ -187,6 +243,10 @@ export class LongAttributeTypeImpl extends AttributeTypeImpl implements LongAttr
         return ValueType.LONG;
     }
 
+    isLong(): boolean {
+        return true;
+    }
+
     asRemote(transaction: Transaction): RemoteLongAttributeTypeImpl {
         return new RemoteLongAttributeTypeImpl(transaction, this.getLabel(), this.isRoot())
     }
@@ -200,6 +260,10 @@ export class RemoteLongAttributeTypeImpl extends RemoteAttributeTypeImpl impleme
 
     getValueType(): ValueType {
         return ValueType.LONG;
+    }
+
+    isLong(): boolean {
+        return true;
     }
 
     asRemote(transaction: Transaction): RemoteLongAttributeTypeImpl {
@@ -241,6 +305,10 @@ export class DoubleAttributeTypeImpl extends AttributeTypeImpl implements Double
         return ValueType.DOUBLE;
     }
 
+    isDouble(): boolean {
+        return true;
+    }
+
     asRemote(transaction: Transaction): RemoteDoubleAttributeTypeImpl {
         return new RemoteDoubleAttributeTypeImpl(transaction, this.getLabel(), this.isRoot())
     }
@@ -258,6 +326,10 @@ export class RemoteDoubleAttributeTypeImpl extends RemoteAttributeTypeImpl imple
 
     asRemote(transaction: Transaction): RemoteDoubleAttributeTypeImpl {
         return new RemoteDoubleAttributeTypeImpl(transaction, this.getLabel(), this.isRoot());
+    }
+
+    isDouble(): boolean {
+        return true;
     }
 
     getSubtypes(): Stream<DoubleAttributeTypeImpl> {
@@ -295,6 +367,10 @@ export class StringAttributeTypeImpl extends AttributeTypeImpl implements String
         return ValueType.STRING;
     }
 
+    isString(): boolean {
+        return true;
+    }
+
     asRemote(transaction: Transaction): RemoteStringAttributeTypeImpl {
         return new RemoteStringAttributeTypeImpl(transaction, this.getLabel(), this.isRoot())
     }
@@ -312,6 +388,10 @@ export class RemoteStringAttributeTypeImpl extends RemoteAttributeTypeImpl imple
 
     asRemote(transaction: Transaction): RemoteStringAttributeTypeImpl {
         return new RemoteStringAttributeTypeImpl(transaction, this.getLabel(), this.isRoot());
+    }
+
+    isString(): boolean {
+        return true;
     }
 
     getSubtypes(): Stream<StringAttributeTypeImpl> {
@@ -349,6 +429,10 @@ export class DateTimeAttributeTypeImpl extends AttributeTypeImpl implements Date
         return ValueType.DATETIME;
     }
 
+    isDateTime(): boolean {
+        return true;
+    }
+
     asRemote(transaction: Transaction): RemoteDateTimeAttributeTypeImpl {
         return new RemoteDateTimeAttributeTypeImpl(transaction, this.getLabel(), this.isRoot())
     }
@@ -362,6 +446,10 @@ export class RemoteDateTimeAttributeTypeImpl extends RemoteAttributeTypeImpl imp
 
     getValueType(): ValueType {
         return ValueType.DATETIME;
+    }
+
+    isDateTime(): boolean {
+        return true;
     }
 
     asRemote(transaction: Transaction): RemoteDateTimeAttributeTypeImpl {

--- a/concept/type/impl/AttributeTypeImpl.ts
+++ b/concept/type/impl/AttributeTypeImpl.ts
@@ -89,10 +89,6 @@ export class RemoteAttributeTypeImpl extends RemoteThingTypeImpl implements Remo
         return super.setSupertype(attributeType);
     }
 
-    getSupertype(): Promise<AttributeTypeImpl> {
-        return super.getSupertype() as Promise<AttributeTypeImpl>;
-    }
-
     getSubtypes(): Stream<AttributeTypeImpl> {
         return super.getSubtypes() as Stream<AttributeTypeImpl>;
     }
@@ -156,10 +152,6 @@ export class RemoteBooleanAttributeTypeImpl extends RemoteAttributeTypeImpl impl
         return new RemoteBooleanAttributeTypeImpl(transaction, this.getLabel(), this.isRoot());
     }
 
-    getSupertype(): Promise<BooleanAttributeTypeImpl> {
-        return super.getSupertype() as Promise<BooleanAttributeTypeImpl>;
-    }
-
     getSubtypes(): Stream<BooleanAttributeTypeImpl> {
         return super.getSubtypes() as Stream<BooleanAttributeTypeImpl>;
     }
@@ -212,10 +204,6 @@ export class RemoteLongAttributeTypeImpl extends RemoteAttributeTypeImpl impleme
 
     asRemote(transaction: Transaction): RemoteLongAttributeTypeImpl {
         return new RemoteLongAttributeTypeImpl(transaction, this.getLabel(), this.isRoot());
-    }
-
-    getSupertype(): Promise<LongAttributeTypeImpl> {
-        return super.getSupertype() as Promise<LongAttributeTypeImpl>;
     }
 
     getSubtypes(): Stream<LongAttributeTypeImpl> {
@@ -272,10 +260,6 @@ export class RemoteDoubleAttributeTypeImpl extends RemoteAttributeTypeImpl imple
         return new RemoteDoubleAttributeTypeImpl(transaction, this.getLabel(), this.isRoot());
     }
 
-    getSupertype(): Promise<DoubleAttributeTypeImpl> {
-        return super.getSupertype() as Promise<DoubleAttributeTypeImpl>;
-    }
-
     getSubtypes(): Stream<DoubleAttributeTypeImpl> {
         return super.getSubtypes() as Stream<DoubleAttributeTypeImpl>;
     }
@@ -330,10 +314,6 @@ export class RemoteStringAttributeTypeImpl extends RemoteAttributeTypeImpl imple
         return new RemoteStringAttributeTypeImpl(transaction, this.getLabel(), this.isRoot());
     }
 
-    getSupertype(): Promise<StringAttributeTypeImpl> {
-        return super.getSupertype() as Promise<StringAttributeTypeImpl>;
-    }
-
     getSubtypes(): Stream<StringAttributeTypeImpl> {
         return super.getSubtypes() as Stream<StringAttributeTypeImpl>;
     }
@@ -386,10 +366,6 @@ export class RemoteDateTimeAttributeTypeImpl extends RemoteAttributeTypeImpl imp
 
     asRemote(transaction: Transaction): RemoteDateTimeAttributeTypeImpl {
         return new RemoteDateTimeAttributeTypeImpl(transaction, this.getLabel(), this.isRoot());
-    }
-
-    getSupertype(): Promise<DateTimeAttributeTypeImpl> {
-        return super.getSupertype() as Promise<DateTimeAttributeTypeImpl>;
     }
 
     getSubtypes(): Stream<DateTimeAttributeTypeImpl> {

--- a/concept/type/impl/AttributeTypeImpl.ts
+++ b/concept/type/impl/AttributeTypeImpl.ts
@@ -93,10 +93,6 @@ export class RemoteAttributeTypeImpl extends RemoteThingTypeImpl implements Remo
         return super.getSupertype() as Promise<AttributeTypeImpl>;
     }
 
-    getSupertypes(): Stream<AttributeTypeImpl> {
-        return super.getSupertypes() as Stream<AttributeTypeImpl>;
-    }
-
     getSubtypes(): Stream<AttributeTypeImpl> {
         return super.getSubtypes() as Stream<AttributeTypeImpl>;
     }
@@ -164,10 +160,6 @@ export class RemoteBooleanAttributeTypeImpl extends RemoteAttributeTypeImpl impl
         return super.getSupertype() as Promise<BooleanAttributeTypeImpl>;
     }
 
-    getSupertypes(): Stream<BooleanAttributeTypeImpl> {
-        return super.getSupertypes() as Stream<BooleanAttributeTypeImpl>;
-    }
-
     getSubtypes(): Stream<BooleanAttributeTypeImpl> {
         return super.getSubtypes() as Stream<BooleanAttributeTypeImpl>;
     }
@@ -224,10 +216,6 @@ export class RemoteLongAttributeTypeImpl extends RemoteAttributeTypeImpl impleme
 
     getSupertype(): Promise<LongAttributeTypeImpl> {
         return super.getSupertype() as Promise<LongAttributeTypeImpl>;
-    }
-
-    getSupertypes(): Stream<LongAttributeTypeImpl> {
-        return super.getSupertypes() as Stream<LongAttributeTypeImpl>;
     }
 
     getSubtypes(): Stream<LongAttributeTypeImpl> {
@@ -288,10 +276,6 @@ export class RemoteDoubleAttributeTypeImpl extends RemoteAttributeTypeImpl imple
         return super.getSupertype() as Promise<DoubleAttributeTypeImpl>;
     }
 
-    getSupertypes(): Stream<DoubleAttributeTypeImpl> {
-        return super.getSupertypes() as Stream<DoubleAttributeTypeImpl>;
-    }
-
     getSubtypes(): Stream<DoubleAttributeTypeImpl> {
         return super.getSubtypes() as Stream<DoubleAttributeTypeImpl>;
     }
@@ -350,10 +334,6 @@ export class RemoteStringAttributeTypeImpl extends RemoteAttributeTypeImpl imple
         return super.getSupertype() as Promise<StringAttributeTypeImpl>;
     }
 
-    getSupertypes(): Stream<StringAttributeTypeImpl> {
-        return super.getSupertypes() as Stream<StringAttributeTypeImpl>;
-    }
-
     getSubtypes(): Stream<StringAttributeTypeImpl> {
         return super.getSubtypes() as Stream<StringAttributeTypeImpl>;
     }
@@ -410,10 +390,6 @@ export class RemoteDateTimeAttributeTypeImpl extends RemoteAttributeTypeImpl imp
 
     getSupertype(): Promise<DateTimeAttributeTypeImpl> {
         return super.getSupertype() as Promise<DateTimeAttributeTypeImpl>;
-    }
-
-    getSupertypes(): Stream<DateTimeAttributeTypeImpl> {
-        return super.getSupertypes() as Stream<DateTimeAttributeTypeImpl>;
     }
 
     getSubtypes(): Stream<DateTimeAttributeTypeImpl> {

--- a/concept/type/impl/EntityTypeImpl.ts
+++ b/concept/type/impl/EntityTypeImpl.ts
@@ -41,11 +41,19 @@ export class EntityTypeImpl extends ThingTypeImpl implements EntityType {
     asRemote(transaction: Transaction): RemoteEntityType {
         return new RemoteEntityTypeImpl(transaction, this.getLabel(), this.isRoot());
     }
+
+    isEntityType(): boolean {
+        return true;
+    }
 }
 
 export class RemoteEntityTypeImpl extends RemoteThingTypeImpl implements RemoteEntityType {
     constructor(transaction: Transaction, label: string, isRoot: boolean) {
         super(transaction, label, isRoot);
+    }
+
+    isEntityType(): boolean {
+        return true;
     }
 
     create(): Promise<EntityImpl> {

--- a/concept/type/impl/EntityTypeImpl.ts
+++ b/concept/type/impl/EntityTypeImpl.ts
@@ -57,10 +57,6 @@ export class RemoteEntityTypeImpl extends RemoteThingTypeImpl implements RemoteE
         return super.getSupertype() as Promise<EntityTypeImpl>;
     }
 
-    getSupertypes(): Stream<EntityTypeImpl> {
-        return super.getSupertypes() as Stream<EntityTypeImpl>;
-    }
-
     getSubtypes(): Stream<EntityTypeImpl> {
         return super.getSubtypes() as Stream<EntityTypeImpl>;
     }

--- a/concept/type/impl/EntityTypeImpl.ts
+++ b/concept/type/impl/EntityTypeImpl.ts
@@ -53,10 +53,6 @@ export class RemoteEntityTypeImpl extends RemoteThingTypeImpl implements RemoteE
         return this.execute(method).then(res => EntityImpl.of(res.getEntityTypeCreateRes().getEntity()));
     }
 
-    getSupertype(): Promise<EntityTypeImpl> {
-        return super.getSupertype() as Promise<EntityTypeImpl>;
-    }
-
     getSubtypes(): Stream<EntityTypeImpl> {
         return super.getSubtypes() as Stream<EntityTypeImpl>;
     }

--- a/concept/type/impl/RelationTypeImpl.ts
+++ b/concept/type/impl/RelationTypeImpl.ts
@@ -91,10 +91,6 @@ export class RemoteRelationTypeImpl extends RemoteThingTypeImpl implements Remot
         return super.setSupertype(relationType);
     }
 
-    getSupertype(): Promise<RelationTypeImpl> {
-        return super.getSupertype() as Promise<RelationTypeImpl>;
-    }
-
     getSubtypes(): Stream<RelationTypeImpl> {
         return super.getSubtypes() as Stream<RelationTypeImpl>;
     }

--- a/concept/type/impl/RelationTypeImpl.ts
+++ b/concept/type/impl/RelationTypeImpl.ts
@@ -95,10 +95,6 @@ export class RemoteRelationTypeImpl extends RemoteThingTypeImpl implements Remot
         return super.getSupertype() as Promise<RelationTypeImpl>;
     }
 
-    getSupertypes(): Stream<RelationTypeImpl> {
-        return super.getSupertypes() as Stream<RelationTypeImpl>;
-    }
-
     getSubtypes(): Stream<RelationTypeImpl> {
         return super.getSubtypes() as Stream<RelationTypeImpl>;
     }

--- a/concept/type/impl/RelationTypeImpl.ts
+++ b/concept/type/impl/RelationTypeImpl.ts
@@ -42,6 +42,10 @@ export class RelationTypeImpl extends ThingTypeImpl implements RelationType {
     asRemote(transaction: Transaction): RemoteRelationTypeImpl {
         return new RemoteRelationTypeImpl(transaction, this.getLabel(), this.isRoot())
     }
+
+    isRelationType(): boolean {
+        return true;
+    }
 }
 
 export class RemoteRelationTypeImpl extends RemoteThingTypeImpl implements RemoteRelationType {
@@ -51,6 +55,10 @@ export class RemoteRelationTypeImpl extends RemoteThingTypeImpl implements Remot
 
     asRemote(transaction: Transaction): RemoteRelationTypeImpl {
         return new RemoteRelationTypeImpl(transaction, this.getLabel(), this.isRoot())
+    }
+
+    isRelationType(): boolean {
+        return true;
     }
 
     create(): Promise<RelationImpl> {

--- a/concept/type/impl/ThingTypeImpl.ts
+++ b/concept/type/impl/ThingTypeImpl.ts
@@ -44,11 +44,19 @@ export class ThingTypeImpl extends TypeImpl implements ThingType {
     asRemote(transaction: Transaction): RemoteThingType {
         return new RemoteThingTypeImpl(transaction, this.getLabel(), this.isRoot());
     }
+
+    isThingType(): boolean {
+        return true;
+    }
 }
 
 export class RemoteThingTypeImpl extends RemoteTypeImpl implements RemoteThingType {
     constructor(transaction: Transaction, label: string, isRoot: boolean) {
         super(transaction, label, isRoot);
+    }
+
+    isThingType(): boolean {
+        return true;
     }
 
     protected setSupertype(thingType: ThingType): Promise<void> {

--- a/concept/type/impl/TypeImpl.ts
+++ b/concept/type/impl/TypeImpl.ts
@@ -127,7 +127,7 @@ export abstract class RemoteTypeImpl implements RemoteType {
     }
 
     async isDeleted(): Promise<boolean> {
-        return !(await this._rpcTransaction.concepts().getType(this._label));
+        return !(await this._rpcTransaction.concepts().getThingType(this._label));
     }
 
     protected get transaction(): Transaction {

--- a/concept/type/impl/TypeImpl.ts
+++ b/concept/type/impl/TypeImpl.ts
@@ -43,6 +43,22 @@ export abstract class TypeImpl implements Type {
         this._root = root;
     }
 
+    isThingType(): boolean {
+        return false;
+    }
+
+    isEntityType(): boolean {
+        return false;
+    }
+
+    isAttributeType(): boolean {
+        return false;
+    }
+
+    isRelationType(): boolean {
+        return false;
+    }
+
     getLabel(): string {
         return this._label;
     }
@@ -73,6 +89,22 @@ export abstract class RemoteTypeImpl implements RemoteType {
         this._rpcTransaction = transaction as RPCTransaction;
         this._label = label;
         this._isRoot = isRoot;
+    }
+
+    isThingType(): boolean {
+        return false;
+    }
+
+    isEntityType(): boolean {
+        return false;
+    }
+
+    isAttributeType(): boolean {
+        return false;
+    }
+
+    isRelationType(): boolean {
+        return false;
     }
 
     getLabel(): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4026,8 +4026,8 @@
       "dev": true
     },
     "grakn-protocol": {
-      "version": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-6bf8c601ecd57a2869cde56c17eec8784a9a2804.tgz",
-      "integrity": "sha512-vCPfG2QoevIG3iFpwOYJWS+FWx4xJlNAZlgJT4yualuhANRCodYx0Uy3xX0Cb8g5ksmJD0VB/PxwUkCn32Y0Rw==",
+      "version": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-590214ea24561b2cc226a469439ce4544e81f6db.tgz",
+      "integrity": "sha512-f95g+/zlBFBYOjf2jctYZUH3O7FzSdL9vr6lRZLCSPytrEO63vMGQHbNp0T2p4ACkKfxiiCEiZB6aSHEKHOb/A==",
       "requires": {
         "@grpc/grpc-js": "1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.2.1",
     "google-protobuf": "3.12.4",
-    "grakn-protocol": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-6bf8c601ecd57a2869cde56c17eec8784a9a2804.tgz"
+    "grakn-protocol": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-590214ea24561b2cc226a469439ce4544e81f6db.tgz"
   },
   "devDependencies": {
     "@bazel/typescript": "2.3.1",

--- a/rpc/RPCSession.ts
+++ b/rpc/RPCSession.ts
@@ -76,7 +76,7 @@ export class RPCSession implements Grakn.Session {
             this._isOpen = false;
             clearTimeout(this._pulse);
             const req = new SessionProto.Session.Close.Req().setSessionId(this._sessionId);
-            await new Promise((resolve, reject) => {
+            await new Promise<void>((resolve, reject) => {
                 this._grpcClient.session_close(req, (err) => {
                     if (err) reject(err);
                     else resolve();


### PR DESCRIPTION
## What is the goal of this PR?

We synchronised client-nodejs's conceptmanager and concept type structure with the newest protocol for grakn core.

## What are the changes implemented in this PR?

getType on the concept manager is now private, and correctly fetches a thingtype (and is named to reflect this), per the new protocol. Additionally, as the base "thing" is now returned by getSupertypes again, the type signatures of getSupertypes have been updated to reflect this.
