### PR TITLE
Validate the dependency declaration correctness before releasing

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -84,11 +84,10 @@ release:
   filter:
     owner: graknlabs
     branch: master
-  # TODO: add it back once we're able to depend on @graknlabs_protocol as bazel rather than artifact dependency
-  # validation:
-  #   validate-dependencies:
-  #     machine: graknlabs-ubuntu-20.04
-  #     script: bazel test //:release-validate-deps --test_output=streamed
+  validation:
+    validate-dependencies:
+      machine: graknlabs-ubuntu-20.04
+      script: bazel test //:release-validate-nodejs-deps --test_output=streamed
   deployment:
     deploy-github:
       machine: graknlabs-ubuntu-20.04

--- a/BUILD
+++ b/BUILD
@@ -29,8 +29,8 @@ load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm", "nodejs_binary")
 load("@graknlabs_bazel_distribution//npm:rules.bzl", "assemble_npm", "deploy_npm")
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@graknlabs_bazel_distribution//artifact:rules.bzl", "artifact_extractor")
-
-load("@graknlabs_dependencies//tool/release:rules.bzl", "release_validate_deps")
+load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("@graknlabs_dependencies//tool/release:rules.bzl", "release_validate_nodejs_deps")
 load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
 load("//:deployment.bzl", github_deployment = "deployment")
 
@@ -116,17 +116,11 @@ artifact_extractor(
     artifact = "@graknlabs_grakn_core_artifact_linux//file",
 )
 
-# TODO: add it back once we're able to depend on @graknlabs_protocol as bazel rather than artifact dependency
-# release_validate_deps(
-#    name = "release-validate-deps",
-#    refs = "@graknlabs_client_nodejs_workspace_refs//:refs.json",
-#    tagged_deps = [
-#      "@graknlabs_protocol",
-#    ],
-#    tags = ["manual"]  # in order for bazel test //... to not fail
-# )
-
-load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+release_validate_nodejs_deps(
+    name = "release-validate-nodejs-deps",
+    package_json = "//:package.json",
+    tagged_deps = ["grakn-protocol"]
+)
 
 checkstyle_test(
     name = "checkstyle",

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -23,7 +23,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "ed2c074bea897dada26e4f112c1d08f739e90012", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "0868c2349040dc89c79eeb2d0198635cd88bbae9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 #TODO: MOVE NATIVE_GRAKN_ARTIFACT INTO DEPENDENCIES, THEN REMOVE THIS DEPENDENCY


### PR DESCRIPTION
## What is the goal of this PR?

Currently, there's no validation happening before the release. We should validate that the version of `grakn-protocol` is available on NpmJS with newly-developed `release_validate_nodejs_deps`

## What are the changes implemented in this PR?

- Upgrade `@graknlabs_dependencies`
- Add `//:release-validate-nodejs-deps`
