### PR TITLE
Remove querypattern

### DIFF
--- a/concept/answer/ConceptMap.ts
+++ b/concept/answer/ConceptMap.ts
@@ -28,11 +28,9 @@ import {
 
 export class ConceptMap {
     private readonly _map: Map<string, Concept>;
-    private readonly _queryPattern: string;
 
-    constructor(map: Map<string, Concept>, pattern: string){
+    constructor(map: Map<string, Concept>){
         this._map = map;
-        this._queryPattern = pattern;
     }
 
     static of(res: AnswerProto.ConceptMap): ConceptMap {
@@ -44,7 +42,7 @@ export class ConceptMap {
             variableMap.set(resLabel, concept);
         })
         const queryPattern = res.getPattern() === "" ? null : res.getPattern();
-        return new ConceptMap(variableMap, queryPattern);
+        return new ConceptMap(variableMap);
     }
 
     map(): Map<string, Concept> {return this._map;}

--- a/concept/answer/ConceptMap.ts
+++ b/concept/answer/ConceptMap.ts
@@ -47,7 +47,6 @@ export class ConceptMap {
         return new ConceptMap(variableMap, queryPattern);
     }
 
-    queryPattern(): string {return this._queryPattern;}
     map(): Map<string, Concept> {return this._map;}
     concepts(): IterableIterator<Concept> {return this._map.values();}
 

--- a/concept/type/AttributeType.ts
+++ b/concept/type/AttributeType.ts
@@ -118,6 +118,9 @@ export interface RemoteStringAttributeType extends Merge<RemoteAttributeType, St
 
     put(value: string): Promise<StringAttribute>;
     get(value: string): Promise<StringAttribute>;
+
+    getRegex(): Promise<String>;
+    setRegex(regex: String): Promise<void>;
 }
 
 export interface DateTimeAttributeType extends AttributeType {

--- a/concept/type/impl/AttributeTypeImpl.ts
+++ b/concept/type/impl/AttributeTypeImpl.ts
@@ -413,6 +413,20 @@ export class RemoteStringAttributeTypeImpl extends RemoteAttributeTypeImpl imple
     get(value: string): Promise<StringAttributeImpl> {
         return this.getInternal(ConceptProtoBuilder.stringAttributeValue(value)) as Promise<StringAttributeImpl>;
     }
+
+    async getRegex(): Promise<string> {
+        return (await this.execute(new ConceptProto.Type.Req().setAttributeTypeGetRegexReq(
+            new ConceptProto.AttributeType.GetRegex.Req()
+        ))).getAttributeTypeGetRegexRes().getRegex();
+    }
+
+    async setRegex(regex: string): Promise<void> {
+        await this.execute(new ConceptProto.Type.Req().setAttributeTypeSetRegexReq(
+            new ConceptProto.AttributeType.SetRegex.Req()
+                .setRegex(regex)
+        ));
+    }
+
 }
 
 export class DateTimeAttributeTypeImpl extends AttributeTypeImpl implements DateTimeAttributeType {

--- a/rpc/RPCSession.ts
+++ b/rpc/RPCSession.ts
@@ -89,7 +89,7 @@ export class RPCSession implements Grakn.Session {
         return this._database;
     }
 
-    pulse(): void {
+    private pulse(): void {
         if (!this._isOpen) return;
         const pulse = new SessionProto.Session.Pulse.Req().setSessionId(this._sessionId);
         this._grpcClient.session_pulse(pulse, (err, res) => {


### PR DESCRIPTION
## What is the goal of this PR?

Fixes assorted inconsistencies between client-nodejs and client-java revealed by working on documentation. This includes removing querypattern, which cannot presently return a useful result, adding regex functionality to stringattributetypes, and preventing the user accessing session heartbeat.

## What are the changes implemented in this PR?

Removes the function queryPattern() from ConceptMaps, as it can only be present if an explanation is present, which it cannot be.
Adds get and set regex for stringattributetypes
Properly sets sessionpulse as private rather than public.