### PR TITLE
Close duplex streams when closing transactions

### DIFF
--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "1573d4144e2898b193ebd17b9b225fd035b99c1e",
+        commit = "7f9f7fbf007e80b3eec48fe8d4918928077d3e37",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -38,5 +38,5 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "8fd31875980767172c100ae65720b129ae928b53", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "9437c38b254d1c9832208004aa78b94f3431e0ec", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/rpc/RPCTransaction.ts
+++ b/rpc/RPCTransaction.ts
@@ -117,8 +117,6 @@ export class RPCTransaction implements Grakn.Transaction {
         if (this._streamIsOpen) {
             this._streamIsOpen = false;
             this._stream.end();
-            //this._stream.cancel();
-            // TODO: close stream, somehow?
         }
         if (!this._transactionWasClosed) {
             this._transactionWasClosed = true;

--- a/rpc/RPCTransaction.ts
+++ b/rpc/RPCTransaction.ts
@@ -116,6 +116,8 @@ export class RPCTransaction implements Grakn.Transaction {
     async close(): Promise<void> {
         if (this._streamIsOpen) {
             this._streamIsOpen = false;
+            this._stream.end();
+            //this._stream.cancel();
             // TODO: close stream, somehow?
         }
         if (!this._transactionWasClosed) {

--- a/rpc/RPCTransaction.ts
+++ b/rpc/RPCTransaction.ts
@@ -155,9 +155,8 @@ export class RPCTransaction implements Grakn.Transaction {
         });
 
         this._stream.on("error", (err) => {
-            this._transactionWasClosed = true;
-            this._streamIsOpen = false;
             this._collectors.clearWithError(new ErrorResponse(err));
+            this.close();
         });
 
         this._stream.on("end", () => {

--- a/test/behaviour/connection/ConnectionSteps.ts
+++ b/test/behaviour/connection/ConnectionSteps.ts
@@ -36,10 +36,11 @@ Given("connection has been opened", () => {
 });
 
 async function clearAll() {
-    if (!client) {
-        client = new GraknClient();
-    }
-    else {
+    if (client) {
+        const databases = await client.databases().all();
+        for (const name of databases) {
+            await client.databases().delete(name);
+        }
         for (const transactionArray of transactions.values()) {
             for (const transaction of transactionArray) {
                 try {
@@ -57,14 +58,8 @@ async function clearAll() {
             }
         }
     }
-    const databases = await client.databases().all();
-    for (const name of databases) {
-        await client.databases().delete(name);
-    }
-    client.close();
     sessions.length = 0;
     transactions.clear();
-    client = null;
 }
 
 Before(clearAll);

--- a/test/behaviour/connection/ConnectionSteps.ts
+++ b/test/behaviour/connection/ConnectionSteps.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Given, After, Before, setDefaultTimeout } from "@cucumber/cucumber";
+import { Given, After, Before, setDefaultTimeout, AfterAll } from "@cucumber/cucumber";
 import { GraknClient } from "../../../dist/rpc/GraknClient";
 import { Grakn } from "../../../dist/Grakn";
 import Session = Grakn.Session;
@@ -35,9 +35,6 @@ Given("connection has been opened", () => {
     client = new GraknClient();
 });
 
-Before(clearAll)
-After(clearAll)
-
 async function clearAll() {
     if (client) {
         for (const session of sessions) {
@@ -45,14 +42,14 @@ async function clearAll() {
                 for (const transaction of transactions.get(session)) {
                     try {
                         await transaction.close();
-                    } catch {
+                    } catch (err) {
                         //We're okay with this.
                     }
                 }
             }
             try {
                 if (session.isOpen()) await session.close()
-            } catch (err){
+            } catch (err) {
                 //We're also okay with this.
             }
         }
@@ -64,3 +61,6 @@ async function clearAll() {
     sessions.length = 0;
     transactions.clear();
 }
+
+Before(clearAll);
+After(clearAll);

--- a/test/behaviour/connection/ConnectionSteps.ts
+++ b/test/behaviour/connection/ConnectionSteps.ts
@@ -45,7 +45,7 @@ async function clearAll() {
             try {
                 await session.close()
             } catch (err) {
-                //We're also okay with this.
+                //We're okay with this.
             }
         }
     }

--- a/test/behaviour/connection/ConnectionSteps.ts
+++ b/test/behaviour/connection/ConnectionSteps.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Given, After, Before, setDefaultTimeout, AfterAll } from "@cucumber/cucumber";
+import { Given, After, Before, setDefaultTimeout } from "@cucumber/cucumber";
 import { GraknClient } from "../../../dist/rpc/GraknClient";
 import { Grakn } from "../../../dist/Grakn";
 import Session = Grakn.Session;

--- a/test/behaviour/connection/ConnectionSteps.ts
+++ b/test/behaviour/connection/ConnectionSteps.ts
@@ -36,30 +36,35 @@ Given("connection has been opened", () => {
 });
 
 async function clearAll() {
-    if (client) {
-        for (const session of sessions) {
-            if (transactions.has(session)){
-                for (const transaction of transactions.get(session)) {
-                    try {
-                        await transaction.close();
-                    } catch (err) {
-                        //We're okay with this.
-                    }
+    if (!client) {
+        client = new GraknClient();
+    }
+    else {
+        for (const transactionArray of transactions.values()) {
+            for (const transaction of transactionArray) {
+                try {
+                    await transaction.close();
+                } catch (err) {
+                    //We're okay with this.
                 }
             }
+        }
+        for (const session of sessions) {
             try {
-                if (session.isOpen()) await session.close()
+                await session.close()
             } catch (err) {
                 //We're also okay with this.
             }
         }
-        const databases = await client.databases().all();
-        for (const name of databases) {
-            await client.databases().delete(name);
-        }
     }
+    const databases = await client.databases().all();
+    for (const name of databases) {
+        await client.databases().delete(name);
+    }
+    client.close();
     sessions.length = 0;
     transactions.clear();
+    client = null;
 }
 
 Before(clearAll);

--- a/test/behaviour/connection/ConnectionSteps.ts
+++ b/test/behaviour/connection/ConnectionSteps.ts
@@ -41,15 +41,6 @@ async function clearAll() {
         for (const name of databases) {
             await client.databases().delete(name);
         }
-        for (const transactionArray of transactions.values()) {
-            for (const transaction of transactionArray) {
-                try {
-                    await transaction.close();
-                } catch (err) {
-                    //We're okay with this.
-                }
-            }
-        }
         for (const session of sessions) {
             try {
                 await session.close()

--- a/test/behaviour/util/Util.ts
+++ b/test/behaviour/util/Util.ts
@@ -19,7 +19,7 @@
 
 import assert = require("assert");
 
-export async function assertThrows(testfunc: () => void): Promise<void> {
+export async function assertThrows(testfunc: () => Promise<any>): Promise<void> {
     try {
         await testfunc();
     } catch {
@@ -29,7 +29,7 @@ export async function assertThrows(testfunc: () => void): Promise<void> {
     assert.fail();
 }
 
-export async function assertThrowsWithMessage(testfunc: () => void, message: string): Promise<void> {
+export async function assertThrowsWithMessage(testfunc: () => Promise<any>, message: string): Promise<void> {
     try {
         await testfunc();
     } catch (error) {


### PR DESCRIPTION
## What is the goal of this PR?

Tests were experiencing intermittent failures due to improper cleanup of transactions. We cleared up the cleanup steps so they're easier to read and less temperamental, and added a step to transaction.close() that actually closes the RPC stream so the tests do not hang sporadically.

## What are the changes implemented in this PR?

We cleaned up connectionsteps in the behavioural tests.
We added _stream.end() to the process of closing transactions.