### PR TITLE
Fix running matchAggregate queries

### DIFF
--- a/concept/answer/Numeric.ts
+++ b/concept/answer/Numeric.ts
@@ -63,4 +63,8 @@ export class Numeric {
     private static ofNaN(): Numeric {
         return new Numeric(null);
     }
+
+    public toString = () : string => {
+        return this.isNumber() ? `${this.asNumber()}` : 'NaN';
+    }
 }

--- a/query/QueryManager.ts
+++ b/query/QueryManager.ts
@@ -99,6 +99,6 @@ export class QueryManager {
     private async runQuery<T>(request: Query.Req, options: GraknOptions, mapper: (res: Transaction.Res) => T): Promise<T> {
         const transactionRequest = new Transaction.Req()
             .setQueryReq(request.setOptions(ProtoBuilder.options(options)));
-        return mapper(await this._rpcTransaction.execute(transactionRequest));
+        return this._rpcTransaction.execute(transactionRequest, mapper);
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Running `tx.query().matchAggregate(q)` now returns correct result instead of throwing an exception. Additionally, the answer returned is now printable.

## What are the changes implemented in this PR?

Fix #148 

Let `RPCTransaction`'s `execute` method handle the mapping instead of doing it in `runQuery`

Make `Numeric` printable with `console.log` by overriding `toString()`