### PR TITLE
Fix console warnings caused by out of date dependency

### DIFF
--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "7f9f7fbf007e80b3eec48fe8d4918928077d3e37",
+        commit = "7644c0194f3e9ba7cee1a3b8964a67086472165d",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -23,7 +23,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "f40b54f36acc91f1ef089058773ec0304dc38ce8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "ca7d021093fe1308b7da52d45809bf06a1d95bc6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 #TODO: MOVE NATIVE_GRAKN_ARTIFACT INTO DEPENDENCIES, THEN REMOVE THIS DEPENDENCY

--- a/package-lock.json
+++ b/package-lock.json
@@ -4290,9 +4290,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.12.4",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.12.4.tgz",
-      "integrity": "sha512-ItTn8YepDQMHEMHloUPH+FDaTPiHTnbsMvP50aXfbI65IK3AA5+wXlHSygJH8xz+h1g4gu7V+CK5X1/SaGITsA=="
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.14.0.tgz",
+      "integrity": "sha512-bwa8dBuMpOxg7COyqkW6muQuvNnWgVN8TX/epDRGW5m0jcrmq2QJyCyiV8ZE2/6LaIIqJtiv9bYokFhfpy/o6w=="
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -4301,8 +4301,8 @@
       "dev": true
     },
     "grakn-protocol": {
-      "version": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-3b8f0d6dc7cd176e59b13e447c64ba41a2ecff7e.tgz",
-      "integrity": "sha512-sL9MP9Iy5wXeCbRwY9/s8+PmvcAP/nTkKyfvyc5SO2iJKOY39Q+qysbNgpftmqtaME/gvL1qk/LMo+HRyfmlqw==",
+      "version": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-dd72ce607c0c3ed91b93f5625afbce6033e82eb7.tgz",
+      "integrity": "sha512-nBnIi+Kb2X6AI0stp/LLmKxbu9dqWZMYW+jfd3fn9fcJ44350Uvj8rfnCqz4LC2G6veL7pPNTwEFrOaBPlvdzw==",
       "requires": {
         "@grpc/grpc-js": "1.2.1"
       }
@@ -4332,6 +4332,14 @@
         "google-protobuf": "3.12.4",
         "handlebars": "4.7.4",
         "handlebars-helpers": "0.10.0"
+      },
+      "dependencies": {
+        "google-protobuf": {
+          "version": "3.12.4",
+          "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.12.4.tgz",
+          "integrity": "sha512-ItTn8YepDQMHEMHloUPH+FDaTPiHTnbsMvP50aXfbI65IK3AA5+wXlHSygJH8xz+h1g4gu7V+CK5X1/SaGITsA==",
+          "dev": true
+        }
       }
     },
     "gtoken": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "1.2.1",
-    "google-protobuf": "3.12.4",
-    "grakn-protocol": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-3b8f0d6dc7cd176e59b13e447c64ba41a2ecff7e.tgz"
+    "google-protobuf": "3.14.0",
+    "grakn-protocol": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-dd72ce607c0c3ed91b93f5625afbce6033e82eb7.tgz"
   },
   "devDependencies": {
     "@bazel/typescript": "2.3.1",


### PR DESCRIPTION
## What is the goal of this PR?

Fix `WARNING: An illegal reflective access operation has occurred` warning caused by an out of date version of protobuf.

## What are the changes implemented in this PR?

- Update protobuf to latest.