### PR TITLE
Reenable remote build caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,35 +17,15 @@
 # under the License.
 #
 
-build --incompatible_strict_action_env
+build --incompatible_strict_action_env --javacopt='--release 8'
 run --incompatible_strict_action_env
 test --incompatible_strict_action_env
 
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev
-build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=cloud.buildbuddy.io
-build:rbe --remote_executor=cloud.buildbuddy.io
 build:rbe --bes_backend=cloud.buildbuddy.io
 build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
 build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
 build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
-build:rbe --host_platform=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --extra_execution_platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/config:cc-toolchain
-build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/cc:toolchain
-build:rbe --jobs=50
 build:rbe --remote_timeout=3600
-build:rbe --bes_timeout=60s
-build:rbe --spawn_strategy=remote,local
-build:rbe --strategy=Javac=remote
-build:rbe --strategy=Closure=remote
-build:rbe --genrule_strategy=remote,local
-build:rbe --define=EXECUTOR=remote
-build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:rbe --experimental_strict_action_env=true

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -37,9 +37,9 @@ build:
     build:
       image: graknlabs-ubuntu-20.04
       command: |
-        bazel build //...
+        bazel build --config=rbe //...
         bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)')
+        bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)')
         npm install
         npm run lint
     test-integration:
@@ -53,11 +53,11 @@ build:
       image: graknlabs-ubuntu-20.04
       command: |
         npm install typescript
-        bazel test //test/behaviour/connection/... --test_output=errors --jobs=1
-        bazel test //test/behaviour/concept/... --test_output=errors --jobs=1
-        bazel test //test/behaviour/graql/language/match/... --test_output=errors --jobs=1
-        bazel test //test/behaviour/graql/language/get/... --test_output=errors --jobs=1
-        bazel test //test/behaviour/graql/language/define/... --test_output=errors --jobs=1
+        bazel test --config=rbe //test/behaviour/connection/... --test_output=errors --jobs=1
+        bazel test --config=rbe //test/behaviour/concept/... --test_output=errors --jobs=1
+        bazel test --config=rbe //test/behaviour/graql/language/match/... --test_output=errors --jobs=1
+        bazel test --config=rbe //test/behaviour/graql/language/get/... --test_output=errors --jobs=1
+        bazel test --config=rbe //test/behaviour/graql/language/define/... --test_output=errors --jobs=1
       # TODO: Remove --jobs=1 once parallelism is functional
     deploy-npm-snapshot:
       filter:
@@ -72,7 +72,7 @@ build:
         export DEPLOY_NPM_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_NPM_PASSWORD=$REPO_GRAKN_PASSWORD
         export DEPLOY_NPM_EMAIL=$REPO_GRAKN_EMAIL
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-npm -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //:deploy-npm -- snapshot
       dependencies: [build, test-integration, test-behaviour]
 
     test-deployment-npm:
@@ -106,7 +106,7 @@ release:
         export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @graknlabs_dependencies//tool/release:create-notes -- client-nodejs $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
+        bazel run --config=rbe --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
     deploy-npm-release:
       image: graknlabs-ubuntu-20.04
       command: |
@@ -117,5 +117,5 @@ release:
         wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
         sudo apt update -y
         sudo apt install -y expect
-        bazel run --define version=$(cat VERSION) //:deploy-npm -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //:deploy-npm -- release
       dependencies: [deploy-github]


### PR DESCRIPTION
## What is the goal of this PR?

Speed up builds by utilizing remote caching provided by BuildBuddy.

## What are the changes implemented in this PR?

Reenable build caching (without remote execution) on all CI jobs