### PR TITLE
Support new Graql Update queries

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -49,16 +49,30 @@ build:
         ./test/integration/test.sh && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         ./test/common/stop-server.sh
         exit $TEST_SUCCESS
-    test-behaviour:
+    test-behaviour-connection:
       image: graknlabs-ubuntu-20.04
       command: |
-        npm install typescript
-        bazel test //test/behaviour/connection/... --test_output=errors --jobs=1
-        bazel test //test/behaviour/concept/... --test_output=errors --jobs=1
-        bazel test //test/behaviour/graql/language/match/... --test_output=errors --jobs=1
-        bazel test //test/behaviour/graql/language/get/... --test_output=errors --jobs=1
-        bazel test //test/behaviour/graql/language/define/... --test_output=errors --jobs=1
-      # TODO: Remove --jobs=1 once parallelism is functional
+        bazel test //test/behaviour/connection/... --test_output=streamed
+    test-behaviour-concept:
+      image: graknlabs-ubuntu-20.04
+      command: |
+        bazel test //test/behaviour/concept/... --test_output=streamed
+    test-behaviour-match:
+      image: graknlabs-ubuntu-20.04
+      command: |
+        bazel test //test/behaviour/graql/language/match/... --test_output=streamed
+        bazel test //test/behaviour/graql/language/get/... --test_output=streamed
+    test-behaviour-writable:
+      image: graknlabs-ubuntu-20.04
+      command: |
+        bazel test //test/behaviour/graql/language/insert/... --test_output=streamed
+        bazel test //test/behaviour/graql/language/delete/... --test_output=streamed
+        bazel test //test/behaviour/graql/language/update/... --test_output=streamed
+    test-behaviour-definable:
+      image: graknlabs-ubuntu-20.04
+      command: |
+        bazel test //test/behaviour/graql/language/define/... --test_output=streamed
+        bazel test //test/behaviour/graql/language/undefine/... --test_output=streamed
     deploy-npm-snapshot:
       filter:
         owner: graknlabs
@@ -73,7 +87,7 @@ build:
         export DEPLOY_NPM_PASSWORD=$REPO_GRAKN_PASSWORD
         export DEPLOY_NPM_EMAIL=$REPO_GRAKN_EMAIL
         bazel run --define version=$(git rev-parse HEAD) //:deploy-npm -- snapshot
-      dependencies: [build, test-integration, test-behaviour]
+      dependencies: [build, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable]
 
     test-deployment-npm:
       filter:

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -37,5 +37,5 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "0e194403ce4cc7fb77fd289c8e87afd80289a04c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "65fa364e971eab81bb9b4929a461d7238ca87b01", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -37,5 +37,5 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "65fa364e971eab81bb9b4929a461d7238ca87b01", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "94b9925539863d94eca8ae0d1571ea0fa2737249", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -4301,8 +4301,8 @@
       "dev": true
     },
     "grakn-protocol": {
-      "version": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-dd72ce607c0c3ed91b93f5625afbce6033e82eb7.tgz",
-      "integrity": "sha512-nBnIi+Kb2X6AI0stp/LLmKxbu9dqWZMYW+jfd3fn9fcJ44350Uvj8rfnCqz4LC2G6veL7pPNTwEFrOaBPlvdzw==",
+      "version": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-633e85f199bd951349206c45594e4090359e9e65.tgz",
+      "integrity": "sha512-bhge1Cyp5RfCGKftwjqVtEimSRWxKUNj9FUcfG+rmnaYpiqN+MwYz0xXW5gO1dralOhh1xpjdSf/hJ7d0X6+hQ==",
       "requires": {
         "@grpc/grpc-js": "1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.2.1",
     "google-protobuf": "3.14.0",
-    "grakn-protocol": "2.0.0-alpha-6"
+    "grakn-protocol": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-633e85f199bd951349206c45594e4090359e9e65.tgz"
   },
   "devDependencies": {
     "@bazel/typescript": "2.3.1",

--- a/query/QueryManager.ts
+++ b/query/QueryManager.ts
@@ -78,6 +78,12 @@ export class QueryManager {
         return this.runQuery(deleteQuery, options ? options : new GraknOptions(), () => null);
     }
 
+    public update(query: string, options?: GraknOptions): Stream<ConceptMap> {
+        const updateQuery = new Query.Req().setUpdateReq(
+            new Query.Update.Req().setQuery(query));
+        return this.iterateQuery(updateQuery, options ? options : new GraknOptions(), (res: Transaction.Res) => res.getQueryRes().getUpdateRes().getAnswersList().map(ConceptMap.of));
+    }
+
     public define(query: string, options?: GraknOptions): Promise<void> {
         const defineQuery = new Query.Req().setDefineReq(
                     new Query.Define.Req().setQuery(query));

--- a/test/behaviour/concept/thing/relation/RelationSteps.ts
+++ b/test/behaviour/concept/thing/relation/RelationSteps.ts
@@ -151,10 +151,12 @@ When("relation {var} add player for role\\({type_label}): {var}", async (relatio
 });
 
 When("relation {var} add player for role\\({type_label}): {var}; throws exception", async (relationName:string, typeLabel: string, playerName: string) => {
-    const relation = get(relationName) as Relation;
-    const roleType = await (await relation.asRemote(tx()).getType()).asRemote(tx()).getRelates(typeLabel);
-    const player = get(playerName);
-    await assertThrows(async () => relation.asRemote(tx()).addPlayer(roleType, player));
+    await assertThrows(async () => {
+        const relation = get(relationName) as Relation;
+        const roleType = await (await relation.asRemote(tx()).getType()).asRemote(tx()).getRelates(typeLabel);
+        const player = get(playerName);
+        await relation.asRemote(tx()).addPlayer(roleType, player);
+    })
 });
 
 When("relation {var} remove player for role\\({type_label}): {var}", async (relationName:string, typeLabel: string, playerName: string) => {

--- a/test/behaviour/concept/thing/relation/RelationSteps.ts
+++ b/test/behaviour/concept/thing/relation/RelationSteps.ts
@@ -150,6 +150,13 @@ When("relation {var} add player for role\\({type_label}): {var}", async (relatio
     await relation.asRemote(tx()).addPlayer(roleType, player);
 });
 
+When("relation {var} add player for role\\({type_label}): {var}; throws exception", async (relationName:string, typeLabel: string, playerName: string) => {
+    const relation = get(relationName) as Relation;
+    const roleType = await (await relation.asRemote(tx()).getType()).asRemote(tx()).getRelates(typeLabel);
+    const player = get(playerName);
+    await assertThrows(async () => relation.asRemote(tx()).addPlayer(roleType, player));
+});
+
 When("relation {var} remove player for role\\({type_label}): {var}", async (relationName:string, typeLabel: string, playerName: string) => {
     const relation = get(relationName) as Relation;
     const roleType = await (await relation.asRemote(tx()).getType()).asRemote(tx()).getRelates(typeLabel);

--- a/test/behaviour/graql/GraqlSteps.ts
+++ b/test/behaviour/graql/GraqlSteps.ts
@@ -100,9 +100,26 @@ Then("graql delete; throws exception", async (query: string) => {
     await assertThrows(async () => await tx().query().delete(query));
 });
 
+When("graql update", (query: string) => {
+    tx().query().update(query);
+});
+
+Then("graql update; throws exception containing {string}", async (exceptionString: string, query: string) => {
+    await assertThrowsWithMessage(async () => await tx().query().update(query).next(), exceptionString);
+});
+
+Then("graql update; throws exception", async (query: string) => {
+    await assertThrows(async () => await tx().query().update(query).next());
+});
+
 When("get answers of graql insert", async (query: string) => {
     clearAnswers();
     answers = await tx().query().insert(query).collect();
+});
+
+When("get answers of graql update", async (query: string) => {
+    clearAnswers();
+    answers = await tx().query().update(query).collect();
 });
 
 When("get answers of graql match", async (query: string) => {

--- a/test/behaviour/graql/GraqlSteps.ts
+++ b/test/behaviour/graql/GraqlSteps.ts
@@ -35,6 +35,7 @@ import DataTable from "@cucumber/cucumber/lib/models/data_table";
 import { fail } from "assert";
 import assert = require("assert");
 import ValueClass = AttributeType.ValueClass;
+import { get } from "../concept/thing/ThingSteps";
 
 let answers: ConceptMap[] = [];
 let numericAnswer: Numeric;
@@ -148,6 +149,19 @@ When("get answers of graql match group aggregate", async (query: string) => {
 
 Then("answer size is: {number}", async (expectedAnswers: number) => {
     assert.strictEqual(answers.length, expectedAnswers, `Expected [${expectedAnswers}], but got [${answers.length}]`);
+});
+
+Then("rules contain: {type_label}", async (ruleLabel: string) => {
+    for await (const rule of (await tx().logic().getRules())) {
+        if (rule.getLabel() === ruleLabel) return;
+    }
+    assert.fail();
+});
+
+Then("rules do not contain: {type_label}", async (ruleLabel: string) => {
+    for await (const rule of (await tx().logic().getRules())) {
+        if (rule.getLabel() === ruleLabel) assert.fail();
+    }
 });
 
 interface ConceptMatcher {

--- a/test/behaviour/graql/language/update/BUILD
+++ b/test/behaviour/graql/language/update/BUILD
@@ -17,15 +17,21 @@
 # under the License.
 #
 
-load("@graknlabs_dependencies//distribution/artifact:rules.bzl", "native_artifact_files")
-load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
+load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("//test/behaviour:rules.bzl", "node_cucumber_test")
 
-def graknlabs_grakn_core_artifacts():
-    native_artifact_files(
-        name = "graknlabs_grakn_core_artifact",
-        group_name = "graknlabs_grakn_core",
-        artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
-        tag_source = deployment["artifact.release"],
-        commit_source = deployment["artifact.snapshot"],
-        commit = "2bcacbdcec59d9419d62974ace513438f46238f5",
-    )
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "apache",
+)
+
+node_cucumber_test(
+    name = "test",
+    features = ["@graknlabs_behaviour//graql/language:update.feature"],
+    node_modules = "//:node_modules",
+    package_json = "//:package.json",
+    core_artifact = "//test:native-grakn-artifact",
+    client = "//:client-nodejs-compiled",
+    steps = "//test/behaviour:behavioural-steps-compiled",
+)


### PR DESCRIPTION
## What is the goal of this PR?

We synchronised client-nodejs with the current master versions of protocol, behavioural tests, and grakn core server, to enable support for the new update query type, as well as adding support for related tests and automation.

## What are the changes implemented in this PR?

- Updated protocol version
- Added update queries to querymanager
- Added test steps for rules, relations, and update queries
- Added insert, delete and match to behavioural tests.
- Reformatted automation.yml

