### PR TITLE
Refactor code to work with latest @graknlabs_dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,8 +47,6 @@ kt_register_toolchains()
 # Load //builder/python
 load("@graknlabs_dependencies//builder/python:deps.bzl", python_deps = "deps")
 python_deps()
-load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
-pip_repositories()
 
 # Load //builder/nodejs
 load("@graknlabs_dependencies//builder/nodejs:deps.bzl", nodejs_deps = "deps")
@@ -87,8 +85,6 @@ node_grpc_compile()
 load("@graknlabs_dependencies//tool/common:deps.bzl", "graknlabs_dependencies_ci_pip",
     graknlabs_dependencies_tool_maven_artifacts = "maven_artifacts")
 graknlabs_dependencies_ci_pip()
-load("@graknlabs_dependencies_ci_pip//:requirements.bzl", "pip_install")
-pip_install()
 
 # Load Unused Deps
 load("@graknlabs_dependencies//tool/unuseddeps:deps.bzl", unuseddeps_deps = "deps")
@@ -110,8 +106,6 @@ rules_pkg_dependencies()
 # Load //pip
 load("@graknlabs_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
 pip_deps()
-load("@graknlabs_bazel_distribution_pip//:requirements.bzl", graknlabs_bazel_distribution_pip_install = "pip_install")
-graknlabs_bazel_distribution_pip_install()
 
 # Load //github
 load("@graknlabs_bazel_distribution//github:deps.bzl", github_deps = "deps")

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -22,7 +22,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "592ff77096653d8bbcbd9f8db8dcc9773f49822e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "36bc9911558dc4a81f1f467d5a080033b62852fe", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 #TODO: MOVE NATIVE_GRAKN_ARTIFACT INTO DEPENDENCIES, THEN REMOVE THIS DEPENDENCY


### PR DESCRIPTION
## What is the goal of this PR?

Latest version of `@graknlabs_dependencies` updates `rules-python` and therefore all repos that depend on it need to bring imports to an up-to-date state.

## What are the changes implemented in this PR?

Update `WORKSPACE` to match latest `@graknlabs_dependencies`