### PR TITLE
Bump protocol to add option for inference tracing

### DIFF
--- a/GraknOptions.ts
+++ b/GraknOptions.ts
@@ -24,6 +24,7 @@ import {
 
 export class GraknOptions {
     private _infer: boolean;
+    private _traceInference: boolean;
     private _explain: boolean;
     private _batchSize: number;
     private _sessionIdleTimeoutMillis: number;
@@ -31,6 +32,7 @@ export class GraknOptions {
 
     constructor() {
         this._infer = null;
+        this._traceInference = null;
         this._explain = null;
         this._batchSize = null;
         this._sessionIdleTimeoutMillis = null;
@@ -43,6 +45,15 @@ export class GraknOptions {
 
     setInfer(infer: boolean): GraknOptions {
         this._infer = infer;
+        return this;
+    }
+
+    traceInference(): boolean {
+       return this._traceInference;
+    }
+
+    setTraceInference(traceInference: boolean): GraknOptions {
+        this._traceInference = traceInference;
         return this;
     }
 

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "4d449aa198fd5cceca54cb3889114ab5aa1b8e5e",
+        commit = "835dd63e64115407af8fb0da27d29a9e2fb8c664",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -30,7 +30,7 @@ def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
         remote = "https://github.com/graknlabs/common",
-        commit = "15a2a883a9375e7dddca00e4c6bd55efdd357469" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        tag = "2.0.0-alpha-9" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_behaviour():

--- a/package-lock.json
+++ b/package-lock.json
@@ -4301,9 +4301,9 @@
       "dev": true
     },
     "grakn-protocol": {
-      "version": "2.0.0-alpha-8",
-      "resolved": "https://registry.npmjs.org/grakn-protocol/-/grakn-protocol-2.0.0-alpha-8.tgz",
-      "integrity": "sha512-29wWnVkCAkoCgSRM4PuJPJSJrbEerFDy53Be/ryXhhZwNEFzUX6GkKJ5aah1SBDGGx68vICANrOMa9drKdAnxQ==",
+      "version": "2.0.0-alpha-10",
+      "resolved": "https://registry.npmjs.org/grakn-protocol/-/grakn-protocol-2.0.0-alpha-10.tgz",
+      "integrity": "sha512-IN2KgHyhcsOTHlDMI8gGVppKmTNWUhO/5RcWOEYlZlJuNjN3KQJ0Uc0CCHmK8CruboT/jd+jATQAewec33dZsg==",
       "requires": {
         "@grpc/grpc-js": "1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.2.1",
     "google-protobuf": "3.14.0",
-    "grakn-protocol": "2.0.0-alpha-8"
+    "grakn-protocol": ".0.0-alpha-10"
   },
   "devDependencies": {
     "@bazel/typescript": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.2.1",
     "google-protobuf": "3.14.0",
-    "grakn-protocol": ".0.0-alpha-10"
+    "grakn-protocol": "2.0.0-alpha-10"
   },
   "devDependencies": {
     "@bazel/typescript": "2.3.1",

--- a/test/BUILD
+++ b/test/BUILD
@@ -18,7 +18,7 @@
 #
 
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_common//test/server:rules.bzl", "native_grakn_artifact")
+load("@graknlabs_common//test:rules.bzl", "native_grakn_artifact")
 load("@graknlabs_bazel_distribution//artifact:rules.bzl", "artifact_extractor")
 
 package(default_visibility = ["//test/behaviour:__subpackages__"])


### PR DESCRIPTION
## What is the goal of this PR?

Bump protocol version to include the option for `traceInference`, which is now available on the server.

## What are the changes implemented in this PR?
* Bump protocol
* Implement new Option `traceInference`
* update VERSION file for release
