### PR TITLE
Rename batchSize option to prefetchSize

### DIFF
--- a/api/GraknOptions.ts
+++ b/api/GraknOptions.ts
@@ -42,7 +42,7 @@ namespace Opts {
             if (options.traceInference != null) optionsProto.setTraceInference(options.traceInference);
             if (options.explain != null) optionsProto.setExplain(options.explain);
             if (options.parallel != null) optionsProto.setParallel(options.parallel);
-            if (options.prefetchSize != null) optionsProto.setBatchSize(options.prefetchSize);
+            if (options.prefetchSize != null) optionsProto.setPrefetchSize(options.prefetchSize);
             if (options.prefetch != null) optionsProto.setPrefetch(options.prefetch);
             if (options.sessionIdleTimeoutMillis != null) optionsProto.setSessionIdleTimeoutMillis(options.sessionIdleTimeoutMillis);
             if (options.schemaLockAcquireTimeoutMillis != null) optionsProto.setSchemaLockAcquireTimeoutMillis(options.schemaLockAcquireTimeoutMillis);

--- a/api/GraknOptions.ts
+++ b/api/GraknOptions.ts
@@ -25,7 +25,7 @@ namespace Opts {
         traceInference?: boolean;
         explain?: boolean;
         parallel?: boolean;
-        batchSize?: number;
+        prefetchSize?: number;
         prefetch?: boolean;
         sessionIdleTimeoutMillis?: number;
         schemaLockAcquireTimeoutMillis?: number;
@@ -42,7 +42,7 @@ namespace Opts {
             if (options.traceInference != null) optionsProto.setTraceInference(options.traceInference);
             if (options.explain != null) optionsProto.setExplain(options.explain);
             if (options.parallel != null) optionsProto.setParallel(options.parallel);
-            if (options.batchSize != null) optionsProto.setBatchSize(options.batchSize);
+            if (options.prefetchSize != null) optionsProto.setBatchSize(options.prefetchSize);
             if (options.prefetch != null) optionsProto.setPrefetch(options.prefetch);
             if (options.sessionIdleTimeoutMillis != null) optionsProto.setSessionIdleTimeoutMillis(options.sessionIdleTimeoutMillis);
             if (options.schemaLockAcquireTimeoutMillis != null) optionsProto.setSchemaLockAcquireTimeoutMillis(options.schemaLockAcquireTimeoutMillis);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@grpc/grpc-js": "1.2.1",
         "google-protobuf": "3.14.0",
-        "grakn-protocol": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-39122114004684f270d78fa7da0e500f4c575e10.tgz",
+        "grakn-protocol": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-efac95a542c5f23b0ee881f7bd618224b0aa7d6c.tgz",
         "uuid": "8.3.2"
       },
       "devDependencies": {
@@ -4714,9 +4714,9 @@
       "dev": true
     },
     "node_modules/grakn-protocol": {
-      "version": "0.0.0-39122114004684f270d78fa7da0e500f4c575e10",
-      "resolved": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-39122114004684f270d78fa7da0e500f4c575e10.tgz",
-      "integrity": "sha512-zFmYTEXoFLVFXYMMl7uHoVHiSYTBVr1kXIdMbtgtxsDqf9znGN2GyqsUPfLycgh5xjBT6XTIoDfnAflyL2G9aQ==",
+      "version": "0.0.0-efac95a542c5f23b0ee881f7bd618224b0aa7d6c",
+      "resolved": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-efac95a542c5f23b0ee881f7bd618224b0aa7d6c.tgz",
+      "integrity": "sha512-a/xtUUDIfLkQe42pF1b5Ji/hUNUY1cusWQA0rsuiepP2HLr8xY1ZtWpHuVgv30JySFH/NzK5r/6fUqD+DarliQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "1.2.1"
@@ -14675,8 +14675,8 @@
       "dev": true
     },
     "grakn-protocol": {
-      "version": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-39122114004684f270d78fa7da0e500f4c575e10.tgz",
-      "integrity": "sha512-zFmYTEXoFLVFXYMMl7uHoVHiSYTBVr1kXIdMbtgtxsDqf9znGN2GyqsUPfLycgh5xjBT6XTIoDfnAflyL2G9aQ==",
+      "version": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-efac95a542c5f23b0ee881f7bd618224b0aa7d6c.tgz",
+      "integrity": "sha512-a/xtUUDIfLkQe42pF1b5Ji/hUNUY1cusWQA0rsuiepP2HLr8xY1ZtWpHuVgv30JySFH/NzK5r/6fUqD+DarliQ==",
       "requires": {
         "@grpc/grpc-js": "1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.2.1",
     "google-protobuf": "3.14.0",
-    "grakn-protocol": "2.0.1",
+    "grakn-protocol": "https://repo.grakn.ai/repository/npm-snapshot/grakn-protocol/-/grakn-protocol-0.0.0-efac95a542c5f23b0ee881f7bd618224b0aa7d6c.tgz",
     "uuid": "8.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## What is the goal of this PR?

The option `batchSize` was misleading as we generally use 'batch' to refer to all of the messages sent by a peer (server or client) within a set time window (eg: 1ms). So we renamed it to `prefetchSize`.

## What are the changes implemented in this PR?

Rename batchSize option to prefetchSize